### PR TITLE
Print out newly added buildpack.toml versions

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -37,7 +37,7 @@ func TestUnitJam(t *testing.T) {
 			err    error
 		)
 
-		path, err = gexec.Build("github.com/paketo-buildpacks/packit/cargo/jam")
+		path, err = gexec.Build("github.com/paketo-buildpacks/jam")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/paketo-buildpacks/packit/cargo/jam/commands"
+	"github.com/paketo-buildpacks/jam/commands"
 )
 
 func main() {

--- a/update_dependencies_test.go
+++ b/update_dependencies_test.go
@@ -417,6 +417,8 @@ api = "0.2"
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(session).Should(gexec.Exit(0), func() string { return string(buffer.Contents()) })
+			Expect(session.Out).To(gbytes.Say("Updating buildpack.toml with new versions: "))
+			Expect(session.Out).To(gbytes.Say("[2.2.5]"))
 
 			buildpackContents, err := os.ReadFile(filepath.Join(buildpackDir, "buildpack.toml"))
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

As a part of https://github.com/paketo-buildpacks/github-config/issues/329, print out the newly added versions to stdout when running `jam update-dependencies` so we can easily see the versions that  are new in the `buildpack.toml`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
