### PR TITLE
Print output version message all on one line for easy parsing

### DIFF
--- a/commands/update_dependencies.go
+++ b/commands/update_dependencies.go
@@ -102,8 +102,7 @@ func updateDependenciesRun(flags updateDependenciesFlags) error {
 		return fmt.Errorf("failed to write buildpack config: %w", err)
 	}
 
-	fmt.Println("Updating buildpack.toml with new versions: ")
-	fmt.Println(newVersions)
+	fmt.Println("Updating buildpack.toml with new versions: ", newVersions)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Print out the newly added version message as a single line for easy parsing.

## Use Cases
<!-- An explanation of the use cases your change enables -->

This is needed to unblock https://github.com/paketo-buildpacks/github-config/pull/339, in which we want to parse the output of the command to get just the slice of versions.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
