### PR TITLE
Removes use of Buildpack.SHA256 field

### DIFF
--- a/internal/buildpack_inspector_test.go
+++ b/internal/buildpack_inspector_test.go
@@ -229,87 +229,93 @@ version = "2.3.4"
 		it("returns a list of dependencies", func() {
 			configs, err := inspector.Dependencies(buildpackage)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(configs).To(Equal([]cargo.Config{
+			Expect(configs).To(Equal([]internal.BuildpackMetadata{
 				{
-					Buildpack: cargo.ConfigBuildpack{
-						ID:      "some-buildpack",
-						Version: "1.2.3",
-					},
-					Metadata: cargo.ConfigMetadata{
-						Dependencies: []cargo.ConfigMetadataDependency{
-							{
-								ID:      "some-dependency",
-								Stacks:  []string{"some-stack"},
-								Version: "1.2.3",
-							},
-							{
-								ID:      "other-dependency",
-								Stacks:  []string{"other-stack"},
-								Version: "2.3.4",
-							},
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "some-buildpack",
+							Version: "1.2.3",
 						},
-						DefaultVersions: map[string]string{
-							"some-dependency":  "1.2.x",
-							"other-dependency": "2.3.x",
-						},
-					},
-					Stacks: []cargo.ConfigStack{
-						{ID: "some-stack"},
-						{ID: "other-stack"},
-					},
-				},
-				{
-					Buildpack: cargo.ConfigBuildpack{
-						ID:      "other-buildpack",
-						Version: "2.3.4",
-					},
-					Metadata: cargo.ConfigMetadata{
-						Dependencies: []cargo.ConfigMetadataDependency{
-							{
-								ID:      "first-dependency",
-								Stacks:  []string{"first-stack"},
-								Version: "4.5.6",
-							},
-							{
-								ID:      "second-dependency",
-								Stacks:  []string{"second-stack"},
-								Version: "5.6.7",
-							},
-						},
-						DefaultVersions: map[string]string{
-							"first-dependency":  "4.5.x",
-							"second-dependency": "5.6.x",
-						},
-					},
-					Stacks: []cargo.ConfigStack{
-						{ID: "first-stack"},
-						{ID: "second-stack"},
-					},
-				},
-				{
-					Buildpack: cargo.ConfigBuildpack{
-						ID:      "meta-buildpack",
-						Version: "3.4.5",
-						SHA256:  "sha256:manifest-sha",
-					},
-					Order: []cargo.ConfigOrder{
-						{
-							Group: []cargo.ConfigOrderGroup{
+						Metadata: cargo.ConfigMetadata{
+							Dependencies: []cargo.ConfigMetadataDependency{
 								{
-									ID:      "some-buildpack",
+									ID:      "some-dependency",
+									Stacks:  []string{"some-stack"},
 									Version: "1.2.3",
 								},
-							},
-						},
-						{
-							Group: []cargo.ConfigOrderGroup{
 								{
-									ID:      "other-buildpack",
+									ID:      "other-dependency",
+									Stacks:  []string{"other-stack"},
 									Version: "2.3.4",
 								},
 							},
+							DefaultVersions: map[string]string{
+								"some-dependency":  "1.2.x",
+								"other-dependency": "2.3.x",
+							},
+						},
+						Stacks: []cargo.ConfigStack{
+							{ID: "some-stack"},
+							{ID: "other-stack"},
 						},
 					},
+				},
+				{
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "other-buildpack",
+							Version: "2.3.4",
+						},
+						Metadata: cargo.ConfigMetadata{
+							Dependencies: []cargo.ConfigMetadataDependency{
+								{
+									ID:      "first-dependency",
+									Stacks:  []string{"first-stack"},
+									Version: "4.5.6",
+								},
+								{
+									ID:      "second-dependency",
+									Stacks:  []string{"second-stack"},
+									Version: "5.6.7",
+								},
+							},
+							DefaultVersions: map[string]string{
+								"first-dependency":  "4.5.x",
+								"second-dependency": "5.6.x",
+							},
+						},
+						Stacks: []cargo.ConfigStack{
+							{ID: "first-stack"},
+							{ID: "second-stack"},
+						},
+					},
+				},
+				{
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "meta-buildpack",
+							Version: "3.4.5",
+						},
+						Order: []cargo.ConfigOrder{
+							{
+								Group: []cargo.ConfigOrderGroup{
+									{
+										ID:      "some-buildpack",
+										Version: "1.2.3",
+									},
+								},
+							},
+							{
+								Group: []cargo.ConfigOrderGroup{
+									{
+										ID:      "other-buildpack",
+										Version: "2.3.4",
+									},
+								},
+							},
+						},
+					},
+					SHA256: "sha256:manifest-sha",
 				},
 			}))
 		})

--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -99,29 +99,29 @@ func printImplementation(writer io.Writer, config cargo.Config) {
 
 }
 
-func (f Formatter) Markdown(configs []cargo.Config) {
+func (f Formatter) Markdown(entries []BuildpackMetadata) {
 	//Language-family case
-	if len(configs) > 1 {
-		var familyConfig cargo.Config
-		for index, config := range configs {
-			if len(config.Order) > 0 {
-				familyConfig = config
-				configs = append(configs[:index], configs[index+1:]...)
+	if len(entries) > 1 {
+		var familyMetadata BuildpackMetadata
+		for index, entry := range entries {
+			if len(entry.Config.Order) > 0 {
+				familyMetadata = entry
+				entries = append(entries[:index], entries[index+1:]...)
 				break
 			}
 		}
 
 		//Header section
-		fmt.Fprintf(f.writer, "## %s %s\n\n**ID:** `%s`\n\n", familyConfig.Buildpack.Name, familyConfig.Buildpack.Version, familyConfig.Buildpack.ID)
-		fmt.Fprintf(f.writer, "**Digest:** `%s`\n\n", familyConfig.Buildpack.SHA256)
+		fmt.Fprintf(f.writer, "## %s %s\n\n**ID:** `%s`\n\n", familyMetadata.Config.Buildpack.Name, familyMetadata.Config.Buildpack.Version, familyMetadata.Config.Buildpack.ID)
+		fmt.Fprintf(f.writer, "**Digest:** `%s`\n\n", familyMetadata.SHA256)
 		fmt.Fprintf(f.writer, "#### Included Buildpackages:\n")
 		fmt.Fprintf(f.writer, "| Name | ID | Version |\n|---|---|---|\n")
-		for _, config := range configs {
-			fmt.Fprintf(f.writer, "| %s | %s | %s |\n", config.Buildpack.Name, config.Buildpack.ID, config.Buildpack.Version)
+		for _, entry := range entries {
+			fmt.Fprintf(f.writer, "| %s | %s | %s |\n", entry.Config.Buildpack.Name, entry.Config.Buildpack.ID, entry.Config.Buildpack.Version)
 		}
 		//Sub Header
 		fmt.Fprintf(f.writer, "\n<details>\n<summary>Order Groupings</summary>\n\n")
-		for _, o := range familyConfig.Order {
+		for _, o := range familyMetadata.Config.Order {
 			fmt.Fprintf(f.writer, "| ID | Version | Optional |\n|---|---|---|\n")
 			for _, g := range o.Group {
 				fmt.Fprintf(f.writer, "| %s | %s | %t |\n", g.ID, g.Version, g.Optional)
@@ -130,36 +130,36 @@ func (f Formatter) Markdown(configs []cargo.Config) {
 		}
 		fmt.Fprintf(f.writer, "</details>\n\n---\n")
 
-		for _, config := range configs {
-			fmt.Fprintf(f.writer, "\n<details>\n<summary>%s %s</summary>\n", config.Buildpack.Name, config.Buildpack.Version)
-			fmt.Fprintf(f.writer, "\n**ID:** `%s`\n\n", config.Buildpack.ID)
-			printImplementation(f.writer, config)
+		for _, entry := range entries {
+			fmt.Fprintf(f.writer, "\n<details>\n<summary>%s %s</summary>\n", entry.Config.Buildpack.Name, entry.Config.Buildpack.Version)
+			fmt.Fprintf(f.writer, "\n**ID:** `%s`\n\n", entry.Config.Buildpack.ID)
+			printImplementation(f.writer, entry.Config)
 			fmt.Fprintf(f.writer, "---\n\n</details>\n")
 		}
 
 	} else { //Implementation case
-		fmt.Fprintf(f.writer, "## %s %s\n", configs[0].Buildpack.Name, configs[0].Buildpack.Version)
-		fmt.Fprintf(f.writer, "\n**ID:** `%s`\n\n", configs[0].Buildpack.ID)
-		fmt.Fprintf(f.writer, "**Digest:** `%s`\n\n", configs[0].Buildpack.SHA256)
-		printImplementation(f.writer, configs[0])
+		fmt.Fprintf(f.writer, "## %s %s\n", entries[0].Config.Buildpack.Name, entries[0].Config.Buildpack.Version)
+		fmt.Fprintf(f.writer, "\n**ID:** `%s`\n\n", entries[0].Config.Buildpack.ID)
+		fmt.Fprintf(f.writer, "**Digest:** `%s`\n\n", entries[0].SHA256)
+		printImplementation(f.writer, entries[0].Config)
 	}
 
 }
 
-func (f Formatter) JSON(configs []cargo.Config) {
+func (f Formatter) JSON(entries []BuildpackMetadata) {
 	var output struct {
 		Buildpackage cargo.Config   `json:"buildpackage"`
 		Children     []cargo.Config `json:"children,omitempty"`
 	}
 
-	output.Buildpackage = configs[0]
+	output.Buildpackage = entries[0].Config
 
-	if len(configs) > 1 {
-		for _, config := range configs {
-			if len(config.Order) > 0 {
-				output.Buildpackage = config
+	if len(entries) > 1 {
+		for _, entry := range entries {
+			if len(entry.Config.Order) > 0 {
+				output.Buildpackage = entry.Config
 			} else {
-				output.Children = append(output.Children, config)
+				output.Children = append(output.Children, entry.Config)
 			}
 		}
 	}

--- a/internal/formatter_test.go
+++ b/internal/formatter_test.go
@@ -26,52 +26,54 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 	context("Markdown", func() {
 		it("returns a list of dependencies", func() {
-			formatter.Markdown([]cargo.Config{
+			formatter.Markdown([]internal.BuildpackMetadata{
 				{
-					Buildpack: cargo.ConfigBuildpack{
-						ID:      "some-buildpack",
-						Name:    "Some Buildpack",
-						Version: "some-version",
-						SHA256:  "sha256:some-buildpack-sha",
-					},
-					Metadata: cargo.ConfigMetadata{
-						Dependencies: []cargo.ConfigMetadataDependency{
-							{
-								ID:           "some-dependency",
-								Stacks:       []string{"some-stack"},
-								Version:      "1.2.3",
-								SHA256:       "one-more-sha",
-								Source:       "some-source",
-								SourceSHA256: "source-sha",
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "some-buildpack",
+							Name:    "Some Buildpack",
+							Version: "some-version",
+						},
+						Metadata: cargo.ConfigMetadata{
+							Dependencies: []cargo.ConfigMetadataDependency{
+								{
+									ID:           "some-dependency",
+									Stacks:       []string{"some-stack"},
+									Version:      "1.2.3",
+									SHA256:       "one-more-sha",
+									Source:       "some-source",
+									SourceSHA256: "source-sha",
+								},
+								{
+									ID:      "some-dependency",
+									Stacks:  []string{"other-stack"},
+									Version: "1.2.3",
+									SHA256:  "one-more-sha",
+								},
+								{
+									ID:      "other-dependency",
+									Stacks:  []string{"some-stack", "other-stack"},
+									Version: "2.3.4",
+									SHA256:  "another-sha",
+								},
+								{
+									ID:      "other-dependency",
+									Stacks:  []string{"other-stack"},
+									Version: "2.3.5",
+									SHA256:  "some-sha",
+								},
 							},
-							{
-								ID:      "some-dependency",
-								Stacks:  []string{"other-stack"},
-								Version: "1.2.3",
-								SHA256:  "one-more-sha",
-							},
-							{
-								ID:      "other-dependency",
-								Stacks:  []string{"some-stack", "other-stack"},
-								Version: "2.3.4",
-								SHA256:  "another-sha",
-							},
-							{
-								ID:      "other-dependency",
-								Stacks:  []string{"other-stack"},
-								Version: "2.3.5",
-								SHA256:  "some-sha",
+							DefaultVersions: map[string]string{
+								"some-dependency":  "1.2.x",
+								"other-dependency": "2.3.x",
 							},
 						},
-						DefaultVersions: map[string]string{
-							"some-dependency":  "1.2.x",
-							"other-dependency": "2.3.x",
+						Stacks: []cargo.ConfigStack{
+							{ID: "some-stack"},
+							{ID: "other-stack"},
 						},
 					},
-					Stacks: []cargo.ConfigStack{
-						{ID: "some-stack"},
-						{ID: "other-stack"},
-					},
+					SHA256: "sha256:some-buildpack-sha",
 				},
 			})
 			Expect(buffer.String()).To(Equal(`## Some Buildpack some-version` +
@@ -104,18 +106,20 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 		context("when dependencies and default-versions are empty", func() {
 			it("returns a list of dependencies", func() {
-				formatter.Markdown([]cargo.Config{
+				formatter.Markdown([]internal.BuildpackMetadata{
 					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "some-buildpack",
-							Name:    "Some Buildpack",
-							Version: "some-version",
-							SHA256:  "sha256:some-buildpack-sha",
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "some-buildpack",
+								Name:    "Some Buildpack",
+								Version: "some-version",
+							},
+							Stacks: []cargo.ConfigStack{
+								{ID: "some-stack"},
+								{ID: "other-stack"},
+							},
 						},
-						Stacks: []cargo.ConfigStack{
-							{ID: "some-stack"},
-							{ID: "other-stack"},
-						},
+						SHA256: "sha256:some-buildpack-sha",
 					},
 				})
 				Expect(buffer.String()).To(Equal(`## Some Buildpack some-version` +
@@ -136,46 +140,48 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 		context("when stacks are empty", func() {
 			it("returns a list of dependencies", func() {
-				formatter.Markdown([]cargo.Config{
+				formatter.Markdown([]internal.BuildpackMetadata{
 					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "some-buildpack",
-							Name:    "Some Buildpack",
-							Version: "some-version",
-							SHA256:  "sha256:some-buildpack-sha",
-						},
-						Metadata: cargo.ConfigMetadata{
-							Dependencies: []cargo.ConfigMetadataDependency{
-								{
-									ID:      "some-dependency",
-									Stacks:  []string{"some-stack"},
-									Version: "1.2.3",
-									SHA256:  "one-more-sha",
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "some-buildpack",
+								Name:    "Some Buildpack",
+								Version: "some-version",
+							},
+							Metadata: cargo.ConfigMetadata{
+								Dependencies: []cargo.ConfigMetadataDependency{
+									{
+										ID:      "some-dependency",
+										Stacks:  []string{"some-stack"},
+										Version: "1.2.3",
+										SHA256:  "one-more-sha",
+									},
+									{
+										ID:      "some-dependency",
+										Stacks:  []string{"other-stack"},
+										Version: "1.2.3",
+										SHA256:  "one-more-sha",
+									},
+									{
+										ID:      "other-dependency",
+										Stacks:  []string{"some-stack", "other-stack"},
+										Version: "2.3.4",
+										SHA256:  "another-sha",
+									},
+									{
+										ID:      "other-dependency",
+										Stacks:  []string{"other-stack"},
+										Version: "2.3.5",
+										SHA256:  "some-sha",
+									},
 								},
-								{
-									ID:      "some-dependency",
-									Stacks:  []string{"other-stack"},
-									Version: "1.2.3",
-									SHA256:  "one-more-sha",
-								},
-								{
-									ID:      "other-dependency",
-									Stacks:  []string{"some-stack", "other-stack"},
-									Version: "2.3.4",
-									SHA256:  "another-sha",
-								},
-								{
-									ID:      "other-dependency",
-									Stacks:  []string{"other-stack"},
-									Version: "2.3.5",
-									SHA256:  "some-sha",
+								DefaultVersions: map[string]string{
+									"some-dependency":  "1.2.x",
+									"other-dependency": "2.3.x",
 								},
 							},
-							DefaultVersions: map[string]string{
-								"some-dependency":  "1.2.x",
-								"other-dependency": "2.3.x",
-							},
 						},
+						SHA256: "sha256:some-buildpack-sha",
 					},
 				})
 				Expect(buffer.String()).To(Equal(`## Some Buildpack some-version` +
@@ -205,61 +211,69 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 		context("when there are order groupings", func() {
 			it("prints the order groupings", func() {
-				formatter.Markdown([]cargo.Config{
+				formatter.Markdown([]internal.BuildpackMetadata{
 					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "order-buildpack",
-							Name:    "Order Buildpack",
-							Version: "order-version",
-							SHA256:  "sha256:order-buildpack-sha",
-						},
-						Order: []cargo.ConfigOrder{
-							{
-								Group: []cargo.ConfigOrderGroup{
-									{
-										ID:      "some-buildpack",
-										Version: "1.2.3",
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "order-buildpack",
+								Name:    "Order Buildpack",
+								Version: "order-version",
+							},
+							Order: []cargo.ConfigOrder{
+								{
+									Group: []cargo.ConfigOrderGroup{
+										{
+											ID:      "some-buildpack",
+											Version: "1.2.3",
+										},
+										{
+											ID:       "optional-buildpack",
+											Version:  "2.3.4",
+											Optional: true,
+										},
 									},
-									{
-										ID:       "optional-buildpack",
-										Version:  "2.3.4",
-										Optional: true,
+								},
+								{
+									Group: []cargo.ConfigOrderGroup{
+										{
+											ID:      "some-buildpack",
+											Version: "1.2.3",
+										},
+										{
+											ID:      "other-buildpack",
+											Version: "3.4.5",
+										},
 									},
 								},
 							},
-							{
-								Group: []cargo.ConfigOrderGroup{
-									{
-										ID:      "some-buildpack",
-										Version: "1.2.3",
-									},
-									{
-										ID:      "other-buildpack",
-										Version: "3.4.5",
-									},
-								},
+						},
+						SHA256: "sha256:order-buildpack-sha",
+					},
+					{
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "some-buildpack",
+								Name:    "Some Buildpack",
+								Version: "1.2.3",
 							},
 						},
 					},
 					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "some-buildpack",
-							Name:    "Some Buildpack",
-							Version: "1.2.3",
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "optional-buildpack",
+								Name:    "Optional Buildpack",
+								Version: "2.3.4",
+							},
 						},
 					},
 					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "optional-buildpack",
-							Name:    "Optional Buildpack",
-							Version: "2.3.4",
-						},
-					},
-					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "other-buildpack",
-							Name:    "Other Buildpack",
-							Version: "3.4.5",
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "other-buildpack",
+								Name:    "Other Buildpack",
+								Version: "3.4.5",
+							},
 						},
 					},
 				})
@@ -328,43 +342,45 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 	context("JSON", func() {
 		it("returns a list of dependencies", func() {
-			formatter.JSON([]cargo.Config{
+			formatter.JSON([]internal.BuildpackMetadata{
 				{
-					Buildpack: cargo.ConfigBuildpack{
-						ID:      "some-buildpack",
-						Version: "some-version",
-					},
-					Metadata: cargo.ConfigMetadata{
-						Dependencies: []cargo.ConfigMetadataDependency{
-							{
-								ID:      "some-dependency",
-								Stacks:  []string{"some-stack"},
-								Version: "1.2.3",
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "some-buildpack",
+							Version: "some-version",
+						},
+						Metadata: cargo.ConfigMetadata{
+							Dependencies: []cargo.ConfigMetadataDependency{
+								{
+									ID:      "some-dependency",
+									Stacks:  []string{"some-stack"},
+									Version: "1.2.3",
+								},
+								{
+									ID:      "some-dependency",
+									Stacks:  []string{"other-stack"},
+									Version: "1.2.3",
+								},
+								{
+									ID:      "other-dependency",
+									Stacks:  []string{"some-stack", "other-stack"},
+									Version: "2.3.4",
+								},
+								{
+									ID:      "other-dependency",
+									Stacks:  []string{"other-stack"},
+									Version: "2.3.5",
+								},
 							},
-							{
-								ID:      "some-dependency",
-								Stacks:  []string{"other-stack"},
-								Version: "1.2.3",
-							},
-							{
-								ID:      "other-dependency",
-								Stacks:  []string{"some-stack", "other-stack"},
-								Version: "2.3.4",
-							},
-							{
-								ID:      "other-dependency",
-								Stacks:  []string{"other-stack"},
-								Version: "2.3.5",
+							DefaultVersions: map[string]string{
+								"some-dependency":  "1.2.x",
+								"other-dependency": "2.3.x",
 							},
 						},
-						DefaultVersions: map[string]string{
-							"some-dependency":  "1.2.x",
-							"other-dependency": "2.3.x",
+						Stacks: []cargo.ConfigStack{
+							{ID: "some-stack"},
+							{ID: "other-stack"},
 						},
-					},
-					Stacks: []cargo.ConfigStack{
-						{ID: "some-stack"},
-						{ID: "other-stack"},
 					},
 				},
 			})
@@ -419,52 +435,56 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 		context("when buildpackage is a meta buildpackage", func() {
 			it("prints the meta buildpackage info and the info of all its children", func() {
-				formatter.JSON([]cargo.Config{
+				formatter.JSON([]internal.BuildpackMetadata{
 					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "some-buildpack",
-							Version: "some-version",
-						},
-						Metadata: cargo.ConfigMetadata{
-							Dependencies: []cargo.ConfigMetadataDependency{
-								{
-									ID:      "some-dependency",
-									Stacks:  []string{"some-stack"},
-									Version: "1.2.3",
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "some-buildpack",
+								Version: "some-version",
+							},
+							Metadata: cargo.ConfigMetadata{
+								Dependencies: []cargo.ConfigMetadataDependency{
+									{
+										ID:      "some-dependency",
+										Stacks:  []string{"some-stack"},
+										Version: "1.2.3",
+									},
+								},
+								DefaultVersions: map[string]string{
+									"some-dependency": "1.2.x",
 								},
 							},
-							DefaultVersions: map[string]string{
-								"some-dependency": "1.2.x",
+							Stacks: []cargo.ConfigStack{
+								{ID: "some-stack"},
 							},
-						},
-						Stacks: []cargo.ConfigStack{
-							{ID: "some-stack"},
 						},
 					},
 					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "some-buildpack",
-							Version: "some-version",
-						},
-						Order: []cargo.ConfigOrder{
-							{
-								Group: []cargo.ConfigOrderGroup{
-									{
-										ID:      "some-buildpack",
-										Version: "1.2.3",
-									},
-									{
-										ID:       "optional-buildpack",
-										Version:  "2.3.4",
-										Optional: true,
+						Config: cargo.Config{
+							Buildpack: cargo.ConfigBuildpack{
+								ID:      "some-buildpack",
+								Version: "some-version",
+							},
+							Order: []cargo.ConfigOrder{
+								{
+									Group: []cargo.ConfigOrderGroup{
+										{
+											ID:      "some-buildpack",
+											Version: "1.2.3",
+										},
+										{
+											ID:       "optional-buildpack",
+											Version:  "2.3.4",
+											Optional: true,
+										},
 									},
 								},
-							},
-							{
-								Group: []cargo.ConfigOrderGroup{
-									{
-										ID:      "other-buildpack",
-										Version: "3.4.5",
+								{
+									Group: []cargo.ConfigOrderGroup{
+										{
+											ID:      "other-buildpack",
+											Version: "3.4.5",
+										},
 									},
 								},
 							},


### PR DESCRIPTION
This field is not an official part of the spec and therefore should not
be part of the config struct

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
