### PR TITLE
Add backticks around stack IDs for markdown summary

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -30,7 +30,7 @@ func printImplementation(writer io.Writer, config cargo.Config) {
 
 		fmt.Fprintf(writer, "#### Supported Stacks:\n")
 		for _, s := range config.Stacks {
-			fmt.Fprintf(writer, "- %s\n", s.ID)
+			fmt.Fprintf(writer, "- `%s`\n", s.ID)
 		}
 		fmt.Fprintln(writer)
 	}

--- a/internal/formatter_test.go
+++ b/internal/formatter_test.go
@@ -80,14 +80,11 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 				"\n\n**ID:** `some-buildpack`\n\n" +
 
-				"**Digest:** `sha256:some-buildpack-sha`" +
-
+				"**Digest:** `sha256:some-buildpack-sha`\n\n" +
+				"#### Supported Stacks:\n" +
+				"- `other-stack`\n" +
+				"- `some-stack`\n" +
 				`
-
-#### Supported Stacks:
-- other-stack
-- some-stack
-
 #### Default Dependency Versions:
 | ID | Version |
 |---|---|
@@ -126,15 +123,12 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 					"\n\n**ID:** `some-buildpack`\n\n" +
 
-					"**Digest:** `sha256:some-buildpack-sha`" +
+					"**Digest:** `sha256:some-buildpack-sha`\n\n" +
 
-					`
-
-#### Supported Stacks:
-- other-stack
-- some-stack
-
-`))
+					"#### Supported Stacks:\n" +
+					"- `other-stack`\n" +
+					"- `some-stack`\n\n",
+				))
 			})
 		})
 

--- a/summarize_test.go
+++ b/summarize_test.go
@@ -274,10 +274,10 @@ version = "3.4.5"
 
 				"\n\n**ID:** `some-buildpack`\n\n" +
 
-				`#### Supported Stacks:
-- other-stack
-- some-stack
-
+				"#### Supported Stacks:\n" +
+				"- `other-stack`\n" +
+				"- `some-stack`\n" +
+				`
 #### Default Dependency Versions:
 | ID | Version |
 |---|---|
@@ -298,11 +298,10 @@ version = "3.4.5"
 <summary>Other Buildpack 2.3.4</summary>` +
 
 				"\n\n**ID:** `other-buildpack`\n\n" +
-
-				`#### Supported Stacks:
-- first-stack
-- second-stack
-
+				"#### Supported Stacks:\n" +
+				"- `first-stack`\n" +
+				"- `second-stack`\n" +
+				`
 #### Default Dependency Versions:
 | ID | Version |
 |---|---|


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Adds backticks around stack IDs for markdown summaries. This is especially important for wildcard stacks (`*`), which would render as a sub-bullet if not made literal.

Closes #30 

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
