### PR TITLE
Adds missing error case to create-stack

### DIFF
--- a/internal/ihop/client.go
+++ b/internal/ihop/client.go
@@ -194,7 +194,7 @@ func (c Client) Build(def DefinitionImage, platform string) (Image, error) {
 		Platform:   platform,
 	})
 	if err != nil {
-		return Image{}, nil
+		return Image{}, fmt.Errorf("failed to initiate image build: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/ihop/client_test.go
+++ b/internal/ihop/client_test.go
@@ -163,6 +163,16 @@ RUN --mount=type=secret,id=test-secret,dst=/temp cat /temp > /secret`), 0600)
 				})
 			})
 
+			context("when the platform is invalid", func() {
+				it("can build images", func() {
+					_, err := client.Build(ihop.DefinitionImage{
+						Dockerfile: filepath.Join(dir, "Dockerfile"),
+						Args:       map[string]string{"test_build_arg": "1"},
+					}, "not a valid platform")
+					Expect(err).To(MatchError(ContainSubstring("failed to initiate image build")))
+				})
+			})
+
 			context("when the image build fails", func() {
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\nRUN \"no such command\""), 0600)

--- a/internal/ihop/client_test.go
+++ b/internal/ihop/client_test.go
@@ -164,7 +164,7 @@ RUN --mount=type=secret,id=test-secret,dst=/temp cat /temp > /secret`), 0600)
 			})
 
 			context("when the platform is invalid", func() {
-				it("can build images", func() {
+				it("returns an error", func() {
 					_, err := client.Build(ihop.DefinitionImage{
 						Dockerfile: filepath.Join(dir, "Dockerfile"),
 						Args:       map[string]string{"test_build_arg": "1"},


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Addresses the specific error mentioned in #68. Does not include wrapping for any other error cases. This was clearly a mistake where we should have been returning an error. I'm not sure of the specifics of what other parts of the codebase we'd want to add wrapped error messages to.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
