### PR TITLE
Adds summary to legacy SBOM output in create-stack

### DIFF
--- a/internal/ihop/sbom.go
+++ b/internal/ihop/sbom.go
@@ -19,6 +19,7 @@ type LegacySBOMPackage struct {
 	Version string                   `json:"version"`
 	Arch    string                   `json:"arch"`
 	Source  *LegacySBOMPackageSource `json:"source,omitempty"`
+	Summary string                   `json:"summary,omitempty"`
 }
 
 // LegacySBOMPackageSource represents a package source as defined in the legacy
@@ -98,7 +99,7 @@ func (s SBOM) LegacyFormat() (string, error) {
 					Version:         metadata.SourceVersion,
 					UpstreamVersion: upstreamVersion,
 				},
-				// TODO: Summary
+				Summary: strings.SplitN(metadata.Description, "\n", 2)[0],
 			})
 
 		case pkg.ApkMetadata:

--- a/internal/ihop/sbom_test.go
+++ b/internal/ihop/sbom_test.go
@@ -36,6 +36,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 							Architecture:  "arm64",
 							Source:        "c-package-source",
 							SourceVersion: "3.1.2-upstream-ubuntu3",
+							Description:   "a package for c\n provides a bunch of c stuff",
 						},
 					},
 					pkg.Package{
@@ -103,7 +104,8 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 						"name": "c-package-source",
 						"version": "3.1.2-upstream-ubuntu3",
 						"upstreamVersion": "3.1.2-upstream"
-					}
+					},
+					"summary": "a package for c"
 				}
 			]`))
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds back support for including the summary field for packages included in the legacy SBOM output from `create-stack`. This was temporarily removed when the package scanning code was swapped to use Syft which didn't yet support reading this metadata. Now that https://github.com/anchore/syft/pull/996 has been merged and released in a version of Syft, we can get to 100% backwards-compatible with our old legacy SBOM output.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
