### PR TITLE
Adds --unbuffered flag to create-stack for really large stack images

### DIFF
--- a/commands/create_stack.go
+++ b/commands/create_stack.go
@@ -20,6 +20,7 @@ type createStackFlags struct {
 	buildOutput string
 	runOutput   string
 	secrets     []string
+	unbuffered  bool
 }
 
 func createStack() *cobra.Command {
@@ -35,6 +36,7 @@ func createStack() *cobra.Command {
 	cmd.Flags().StringVar(&flags.buildOutput, "build-output", "", "path to output the build image OCI archive (required)")
 	cmd.Flags().StringVar(&flags.runOutput, "run-output", "", "path to output the run image OCI archive (required)")
 	cmd.Flags().StringSliceVar(&flags.secrets, "secret", nil, "secret to be passed to your Dockerfile")
+	cmd.Flags().BoolVar(&flags.unbuffered, "unbuffered", false, "do not buffer image contents into memory for fast access")
 
 	err := cmd.MarkFlagRequired("config")
 	if err != nil {
@@ -55,7 +57,7 @@ func createStack() *cobra.Command {
 }
 
 func createStackRun(flags createStackFlags) error {
-	definition, err := ihop.NewDefinitionFromFile(flags.config, flags.secrets...)
+	definition, err := ihop.NewDefinitionFromFile(flags.config, flags.unbuffered, flags.secrets...)
 	if err != nil {
 		return err
 	}

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -66,6 +66,8 @@ type DefinitionImage struct {
 
 	// UID is the cnb user id to be specified in the image.
 	UID int `toml:"uid"`
+
+	unbuffered bool
 }
 
 // DefinitionDeprecated defines the deprecated features of the stack.
@@ -91,7 +93,7 @@ func (i DefinitionImage) Arguments() []string {
 }
 
 // NewDefinitionFromFile parses the stack descriptor from a file location.
-func NewDefinitionFromFile(path string, secrets ...string) (Definition, error) {
+func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Definition, error) {
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return Definition{}, err
@@ -174,6 +176,9 @@ func NewDefinitionFromFile(path string, secrets ...string) (Definition, error) {
 
 		definition.Run.Secrets = definition.Build.Secrets
 	}
+
+	definition.Build.unbuffered = unbuffered
+	definition.Run.unbuffered = unbuffered
 
 	return definition, nil
 }

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -63,7 +63,7 @@ platforms = ["some-stack-platform"]
 		})
 
 		it("creates a definition from a config file", func() {
-			definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+			definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(definition).To(Equal(ihop.Definition{
 				ID:         "some-stack-id",
@@ -117,7 +117,7 @@ id = "some-stack-id"
 				})
 
 				it("sets the defaults", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(definition).To(Equal(ihop.Definition{
 						ID:        "some-stack-id",
@@ -157,7 +157,7 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'id' is a required field"))
 				})
 			})
@@ -180,7 +180,7 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.dockerfile' is a required field"))
 				})
 			})
@@ -203,7 +203,7 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.uid' is a required field"))
 				})
 			})
@@ -227,7 +227,7 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.gid' is a required field"))
 				})
 			})
@@ -250,7 +250,7 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.dockerfile' is a required field"))
 				})
 			})
@@ -273,7 +273,7 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.uid' is a required field"))
 				})
 			})
@@ -296,7 +296,7 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.gid' is a required field"))
 				})
 			})
@@ -304,7 +304,7 @@ id = "some-stack-id"
 
 		context("when secrets are given", func() {
 			it("includes them in the build/run image definitions", func() {
-				definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), "first-secret=first-value", "second-secret=second-value")
+				definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false, "first-secret=first-value", "second-secret=second-value")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(definition.Build.Secrets).To(Equal(map[string]string{
 					"first-secret":  "first-value",
@@ -320,7 +320,7 @@ id = "some-stack-id"
 		context("failure cases", func() {
 			context("when the file cannot be opened", func() {
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile("this file does not exist")
+					_, err := ihop.NewDefinitionFromFile("this file does not exist", false)
 					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 				})
 			})
@@ -332,14 +332,14 @@ id = "some-stack-id"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError(ContainSubstring("but got '%' instead")))
 				})
 			})
 
 			context("when a secret is malformed", func() {
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), "this secret is malformed")
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false, "this secret is malformed")
 					Expect(err).To(MatchError("malformed secret: \"this secret is malformed\" must be in the form \"key=value\""))
 				})
 			})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
If the image being built is very large, then the default behavior of the `go-containerregistry` library for interacting with the image layers can put considerable pressure on memory. The default behavior of this library will read the entire image into memory when access internal details like the image config or layers. To prevent memory from being exhausted, the library allows consumers to interact with the image in an unbuffered form, but at the cost of time. This PR adds a flag that allows users to enable this unbuffered behavior if their image is consuming too much memory on the machine used to build the stack.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Enables https://github.com/paketo-buildpacks/jammy-full-stack/issues/3

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
