### PR TITLE
copy etc folder in UserLayerCreator

### DIFF
--- a/internal/ihop/user_layer_creator_test.go
+++ b/internal/ihop/user_layer_creator_test.go
@@ -58,7 +58,8 @@ func testUserLayerCreator(t *testing.T, context spec.G, it spec.S) {
 		}
 
 		Expect(files).To(SatisfyAll(
-			HaveLen(3),
+			HaveLen(4),
+			HaveKeyWithValue("etc/", BeNil()),
 			HaveKeyWithValue("etc/group", ContainSubstring("cnb:x:1234:")),
 			HaveKeyWithValue("etc/passwd", ContainSubstring("cnb:x:4567:1234::/home/cnb:/bin/sh")),
 			HaveKeyWithValue("home/cnb", BeNil()),


### PR DESCRIPTION
## Summary

This change adds the `etc` folder to the generated tar file, before modifying the `etc/group` and `etc/passwd` files in `UserLayerCreator`. Creating folder explicitly seems common practice in tar files.

## Use Cases

Currently, pushing a CNB built image that uses a stack created by `jam` to Cloud Foundry fails:

```
failed to create container for instance c8c6d071-39a2-4110-5ccd-4754: failed to cr
eate shim task: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:76: m
ounting "/var/vcap/data/rep/shared/garden/trusted_certs" to rootfs at "/etc/cf-system-certificates" caused: mkdir /var/vcap/data/grootfs/store/unprivileged/images/c8c6d
071-39a2-4110-5ccd-4754/rootfs/etc/cf-system-certificates: permission denied: unknown
```

Maybe this could be fixed in [`runc`](https://github.com/opencontainers/runc/) or [`grootfs`](https://github.com/cloudfoundry/grootfs), but as docker writes the layer tars containing any intermediate directory I think it would be a good idea, if `jam` did this as well, otherwise the next problem will follow soon.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
