### PR TITLE
Ensure image tags

### DIFF
--- a/internal/image.go
+++ b/internal/image.go
@@ -83,6 +83,10 @@ func FindLatestImage(uri string) (Image, error) {
 		versions = append(versions, version)
 	}
 
+	if len(versions) == 0 {
+		return Image{}, fmt.Errorf("could not find any valid tag for %s", repo.Name())
+	}
+
 	sort.Sort(semver.Collection(versions))
 
 	return Image{
@@ -142,6 +146,10 @@ func FindLatestBuildImage(runURI, buildURI string) (Image, error) {
 		}
 
 		versions = append(versions, version)
+	}
+
+	if len(versions) == 0 {
+		return Image{}, fmt.Errorf("could not find any valid tag for %s", repo.Name())
 	}
 
 	sort.Sort(semver.Collection(versions))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This small enhancement ensures that at least one tag/version exists for a given image is available and returns an error if that is not the case.

## Use Cases
Safety net for non existing tags/versions, preventing a panic a few lines later.

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
