### PR TITLE
Update /etc/os-release based on stack.toml content

### DIFF
--- a/commands/create_stack.go
+++ b/commands/create_stack.go
@@ -77,7 +77,7 @@ func createStackRun(flags createStackFlags) error {
 
 	builder := ihop.NewBuilder(client, ihop.Cataloger{}, runtime.NumCPU())
 	logger := scribe.NewLogger(os.Stdout)
-	creator := ihop.NewCreator(client, builder, ihop.UserLayerCreator{}, ihop.SBOMLayerCreator{}, time.Now, logger)
+	creator := ihop.NewCreator(client, builder, ihop.UserLayerCreator{}, ihop.SBOMLayerCreator{}, ihop.OsReleaseLayerCreator{Def: definition}, time.Now, logger)
 
 	stack, err := creator.Execute(definition)
 	if err != nil {

--- a/integration/create_stack_test.go
+++ b/integration/create_stack_test.go
@@ -196,6 +196,10 @@ func testCreateStack(t *testing.T, _ spec.G, it spec.S) {
 			Expect(image).To(SatisfyAll(
 				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
 				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1001:1000::/home/cnb:/bin/bash")),
+				HaveFileWithContent("/etc/os-release", ContainSubstring(`PRETTY_NAME="Example Stack"`)),
+				HaveFileWithContent("/etc/os-release", ContainSubstring(`HOME_URL="https://github.com/paketo-buildpacks/stacks"`)),
+				HaveFileWithContent("/etc/os-release", ContainSubstring(`SUPPORT_URL="https://github.com/paketo-buildpacks/stacks/blob/main/README.md"`)),
+				HaveFileWithContent("/etc/os-release", ContainSubstring(`BUG_REPORT_URL="https://github.com/paketo-buildpacks/stacks/issues/new"`)),
 				HaveDirectory("/home/cnb"),
 			))
 
@@ -231,6 +235,7 @@ func testCreateStack(t *testing.T, _ spec.G, it spec.S) {
 				"      Adding io.buildpacks.stack.mixins label",
 				"      Adding io.paketo.stack.packages label",
 				"      Creating cnb user",
+				"      Updating /etc/os-release",
 				"      Attaching experimental SBOM",
 				"    build: Updating image",
 				"    run: Updating image",
@@ -249,6 +254,7 @@ func testCreateStack(t *testing.T, _ spec.G, it spec.S) {
 				"      Adding io.buildpacks.stack.mixins label",
 				"      Adding io.paketo.stack.packages label",
 				"      Creating cnb user",
+				"      Updating /etc/os-release",
 				"      Attaching experimental SBOM",
 				"    build: Updating image",
 				"    run: Updating image",

--- a/integration/testdata/example-stack/stack.toml
+++ b/integration/testdata/example-stack/stack.toml
@@ -1,4 +1,5 @@
 id = "io.paketo.stacks.example"
+name = "Example Stack"
 
 homepage = "https://github.com/paketo-buildpacks/stacks"
 maintainer = "Paketo Buildpacks"

--- a/internal/ihop/creator.go
+++ b/internal/ihop/creator.go
@@ -119,13 +119,15 @@ func (c Creator) create(def Definition, platform string) (Image, Image, error) {
 		return Image{}, Image{}, err
 	}
 
-	// update /etc/os-release" in the run images in the Docker daemon
-	c.logger.Action("Updating /etc/os-release")
-	layer, err := c.osReleaseLayerCreator.Create(run, def.Run, runSBOM)
-	if err != nil {
-		return Image{}, Image{}, err
+	if def.containsOsReleasOverwrites() {
+		// update /etc/os-release" in the run images in the Docker daemon
+		c.logger.Action("Updating /etc/os-release")
+		layer, err := c.osReleaseLayerCreator.Create(run, def.Run, runSBOM)
+		if err != nil {
+			return Image{}, Image{}, err
+		}
+		run.Layers = append(run.Layers, layer)
 	}
-	run.Layers = append(run.Layers, layer)
 
 	// if the EXPERIMENTAL_ATTACH_RUN_IMAGE_SBOM environment variable is set,
 	// attach an SBOM layer to the run image

--- a/internal/ihop/creator.go
+++ b/internal/ihop/creator.go
@@ -119,7 +119,7 @@ func (c Creator) create(def Definition, platform string) (Image, Image, error) {
 		return Image{}, Image{}, err
 	}
 
-	if def.containsOsReleasOverwrites() {
+	if def.containsOsReleaseOverwrites() {
 		// update /etc/os-release" in the run images in the Docker daemon
 		c.logger.Action("Updating /etc/os-release")
 		layer, err := c.osReleaseLayerCreator.Create(run, def.Run, runSBOM)

--- a/internal/ihop/creator_test.go
+++ b/internal/ihop/creator_test.go
@@ -432,6 +432,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 		it("creates a multi-arch stack", func() {
 			stack, err := creator.Execute(ihop.Definition{
 				ID:        "some-stack-id",
+				Name:      "Some Name",
 				Platforms: []string{"some-platform", "other-platform"},
 				Build: ihop.DefinitionImage{
 					Dockerfile: "test-base-build-dockerfile-path",

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -14,8 +14,17 @@ type Definition struct {
 	// ID is the stack id applied to the built images.
 	ID string `toml:"id"`
 
+	// Name is a human readable name of the stack.
+	Name string `toml:"name"`
+
 	// Homepage is the homepage for the stack.
 	Homepage string `toml:"homepage"`
+
+	// SupportURL is the support homepage for the stack.
+	SupportURL string `toml:"support-url"`
+
+	// BugReportURL is the bug report homepage for the stack.
+	BugReportURL string `toml:"bug-report-url"`
 
 	// Maintainer is the named individual or group responsible for maintaining
 	// the stack.
@@ -114,6 +123,8 @@ func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Def
 	// check that all required fields are set
 	for field, v := range map[string]any{
 		"id":               definition.ID,
+		"name":             definition.Name,
+		"homepage":         definition.Homepage,
 		"build.dockerfile": definition.Build.Dockerfile,
 		"build.uid":        definition.Build.UID,
 		"build.gid":        definition.Build.GID,
@@ -149,6 +160,14 @@ func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Def
 
 	if definition.Run.Shell == "" {
 		definition.Run.Shell = "/sbin/nologin"
+	}
+
+	if definition.SupportURL == "" {
+		definition.SupportURL = fmt.Sprintf("%s/blob/main/README.md", strings.TrimSuffix(definition.Homepage, "/"))
+	}
+
+	if definition.BugReportURL == "" {
+		definition.BugReportURL = fmt.Sprintf("%s/issues/new", strings.TrimSuffix(definition.Homepage, "/"))
 	}
 
 	// convert the Dockerfile paths given in the stack descriptor to absolute

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -162,11 +162,11 @@ func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Def
 		definition.Run.Shell = "/sbin/nologin"
 	}
 
-	if definition.SupportURL == "" {
+	if definition.SupportURL == "" && strings.Contains(definition.Homepage, "github.com") {
 		definition.SupportURL = fmt.Sprintf("%s/blob/main/README.md", strings.TrimSuffix(definition.Homepage, "/"))
 	}
 
-	if definition.BugReportURL == "" {
+	if definition.BugReportURL == "" && strings.Contains(definition.Homepage, "github.com") {
 		definition.BugReportURL = fmt.Sprintf("%s/issues/new", strings.TrimSuffix(definition.Homepage, "/"))
 	}
 

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -123,8 +123,6 @@ func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Def
 	// check that all required fields are set
 	for field, v := range map[string]any{
 		"id":               definition.ID,
-		"name":             definition.Name,
-		"homepage":         definition.Homepage,
 		"build.dockerfile": definition.Build.Dockerfile,
 		"build.uid":        definition.Build.UID,
 		"build.gid":        definition.Build.GID,
@@ -200,6 +198,10 @@ func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Def
 	definition.Run.unbuffered = unbuffered
 
 	return definition, nil
+}
+
+func (d Definition) containsOsReleasOverwrites() bool {
+	return d.Name != "" || d.Homepage != "" || d.SupportURL != "" || d.BugReportURL != ""
 }
 
 // DefinitionRequiredFieldError defines the error message when a required field

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -200,7 +200,7 @@ func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Def
 	return definition, nil
 }
 
-func (d Definition) containsOsReleasOverwrites() bool {
+func (d Definition) containsOsReleaseOverwrites() bool {
 	return d.Name != "" || d.Homepage != "" || d.SupportURL != "" || d.BugReportURL != ""
 }
 

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -24,7 +24,11 @@ func testDefinition(t *testing.T, context spec.G, it spec.S) {
 
 			err = os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
 homepage = "some-stack-homepage"
+support-url = "some-stack-support-url"
+bug-report-url = "some-stack-bug-report-url"
+
 maintainer = "some-stack-maintainer"
 
 platforms = ["some-stack-platform"]
@@ -66,10 +70,13 @@ platforms = ["some-stack-platform"]
 			definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(definition).To(Equal(ihop.Definition{
-				ID:         "some-stack-id",
-				Homepage:   "some-stack-homepage",
-				Maintainer: "some-stack-maintainer",
-				Platforms:  []string{"some-stack-platform"},
+				ID:           "some-stack-id",
+				Name:         "some-stack-name",
+				Homepage:     "some-stack-homepage",
+				SupportURL:   "some-stack-support-url",
+				BugReportURL: "some-stack-bug-report-url",
+				Maintainer:   "some-stack-maintainer",
+				Platforms:    []string{"some-stack-platform"},
 				Deprecated: ihop.DefinitionDeprecated{
 					LegacySBOM: true,
 					Mixins:     true,
@@ -102,6 +109,8 @@ platforms = ["some-stack-platform"]
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
 
 [build]
 	dockerfile = "some-build-dockerfile"
@@ -120,8 +129,12 @@ id = "some-stack-id"
 					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(definition).To(Equal(ihop.Definition{
-						ID:        "some-stack-id",
-						Platforms: []string{"linux/amd64"},
+						ID:           "some-stack-id",
+						Name:         "some-stack-name",
+						Platforms:    []string{"linux/amd64"},
+						Homepage:     "some-stack-homepage",
+						SupportURL:   "some-stack-homepage/blob/main/README.md",
+						BugReportURL: "some-stack-homepage/issues/new",
 						Build: ihop.DefinitionImage{
 							Dockerfile: filepath.Join(dir, "some-build-dockerfile"),
 							UID:        1234,
@@ -143,6 +156,9 @@ id = "some-stack-id"
 			context("when id is missing", func() {
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
+name = "some-stack-name"
+homepage = "some-stack-homepage"
+
 [build]
 	dockerfile = "some-build-dockerfile"
 	uid = 1234
@@ -162,10 +178,62 @@ id = "some-stack-id"
 				})
 			})
 
+			context("when homepage is missing", func() {
+				it.Before(func() {
+					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
+id = "some-stack-id" 
+name = "some-stack-name"
+
+[build]
+	dockerfile = "some-build-dockerfile"
+	uid = 1234
+	gid = 2345
+
+[run]
+	dockerfile = "some-run-dockerfile"
+	uid = 1234
+	gid = 2345
+`), 0600)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("returns an error", func() {
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					Expect(err).To(MatchError("failed to parse stack descriptor: 'homepage' is a required field"))
+				})
+			})
+
+			context("when name is missing", func() {
+				it.Before(func() {
+					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
+id = "some-stack-id" 
+homepage = "some-stack-homepage"
+
+[build]
+	dockerfile = "some-build-dockerfile"
+	uid = 1234
+	gid = 2345
+
+[run]
+	dockerfile = "some-run-dockerfile"
+	uid = 1234
+	gid = 2345
+`), 0600)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("returns an error", func() {
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					Expect(err).To(MatchError("failed to parse stack descriptor: 'name' is a required field"))
+				})
+			})
+
 			context("when build.dockerfile is missing", func() {
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
 
 [build]
 	uid = 1234
@@ -189,6 +257,8 @@ id = "some-stack-id"
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
 
 [build]
 	dockerfile = "some-build-dockerfile"
@@ -212,6 +282,8 @@ id = "some-stack-id"
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
 
 [build]
 	dockerfile = "some-build-dockerfile"
@@ -236,6 +308,8 @@ id = "some-stack-id"
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
 
 [build]
 	dockerfile = "some-build-dockerfile"
@@ -259,6 +333,8 @@ id = "some-stack-id"
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
 
 [build]
 	dockerfile = "some-build-dockerfile"
@@ -282,6 +358,8 @@ id = "some-stack-id"
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
 
 [build]
 	dockerfile = "some-build-dockerfile"

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -110,7 +110,7 @@ platforms = ["some-stack-platform"]
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
 id = "some-stack-id"
 name = "some-stack-name"
-homepage = "some-stack-homepage"
+homepage = "https://github.com/some-stack"
 
 [build]
 	dockerfile = "some-build-dockerfile"
@@ -132,9 +132,9 @@ homepage = "some-stack-homepage"
 						ID:           "some-stack-id",
 						Name:         "some-stack-name",
 						Platforms:    []string{"linux/amd64"},
-						Homepage:     "some-stack-homepage",
-						SupportURL:   "some-stack-homepage/blob/main/README.md",
-						BugReportURL: "some-stack-homepage/issues/new",
+						Homepage:     "https://github.com/some-stack",
+						SupportURL:   "https://github.com/some-stack/blob/main/README.md",
+						BugReportURL: "https://github.com/some-stack/issues/new",
 						Build: ihop.DefinitionImage{
 							Dockerfile: filepath.Join(dir, "some-build-dockerfile"),
 							UID:        1234,

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -178,56 +178,6 @@ homepage = "some-stack-homepage"
 				})
 			})
 
-			context("when homepage is missing", func() {
-				it.Before(func() {
-					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
-id = "some-stack-id" 
-name = "some-stack-name"
-
-[build]
-	dockerfile = "some-build-dockerfile"
-	uid = 1234
-	gid = 2345
-
-[run]
-	dockerfile = "some-run-dockerfile"
-	uid = 1234
-	gid = 2345
-`), 0600)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
-					Expect(err).To(MatchError("failed to parse stack descriptor: 'homepage' is a required field"))
-				})
-			})
-
-			context("when name is missing", func() {
-				it.Before(func() {
-					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
-id = "some-stack-id" 
-homepage = "some-stack-homepage"
-
-[build]
-	dockerfile = "some-build-dockerfile"
-	uid = 1234
-	gid = 2345
-
-[run]
-	dockerfile = "some-run-dockerfile"
-	uid = 1234
-	gid = 2345
-`), 0600)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
-					Expect(err).To(MatchError("failed to parse stack descriptor: 'name' is a required field"))
-				})
-			})
-
 			context("when build.dockerfile is missing", func() {
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`

--- a/internal/ihop/image.go
+++ b/internal/ihop/image.go
@@ -1,0 +1,96 @@
+package ihop
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+func findFile(image v1.Image, filepath string) (*tar.Header, io.Reader, error) {
+	layers, err := image.Layers()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for i := len(layers) - 1; i >= 0; i-- {
+		layer, err := layers[i].Uncompressed()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var (
+			found  bool
+			header *tar.Header
+			reader io.Reader
+		)
+
+		tr := tar.NewReader(layer)
+		for {
+			hdr, err := tr.Next()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, nil, err
+			}
+
+			if strings.TrimPrefix(hdr.Name, "/") == strings.TrimPrefix(filepath, "/") {
+				found = true
+				if hdr.Typeflag == tar.TypeSymlink {
+					header, reader, err = findFile(image, path.Join(path.Dir(filepath), hdr.Linkname))
+					if err != nil {
+						return nil, nil, err
+					}
+
+					break
+				}
+
+				buffer := bytes.NewBuffer(nil)
+				_, err = io.CopyN(buffer, tr, hdr.Size)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				header = hdr
+				reader = buffer
+				break
+			}
+		}
+
+		err = layer.Close()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if found {
+			return header, reader, nil
+		}
+	}
+
+	return nil, nil, nil
+}
+
+func tarToLayer(reader *os.File) (Layer, error) {
+	layer, err := tarball.LayerFromFile(reader.Name())
+	if err != nil {
+		return Layer{}, err
+	}
+
+	diffID, err := layer.DiffID()
+	if err != nil {
+		return Layer{}, err
+	}
+
+	return Layer{
+		DiffID: diffID.String(),
+		Layer:  layer,
+	}, nil
+}

--- a/internal/ihop/init_test.go
+++ b/internal/ihop/init_test.go
@@ -45,6 +45,7 @@ func TestIHOP(t *testing.T) {
 	suite("SBOM", testSBOM)
 	suite("SBOMLayerCreator", testSBOMLayerCreator)
 	suite("UserLayerCreator", testUserLayerCreator)
+	suite("OsReleaseLayerCreator", testOsReleaseLayerCreator)
 	suite.Run(t)
 
 	_, err = client.ImageRemove(context.Background(), "busybox:latest", types.ImageRemoveOptions{Force: true})

--- a/internal/ihop/os_release_layer_creator.go
+++ b/internal/ihop/os_release_layer_creator.go
@@ -44,7 +44,7 @@ func (o OsReleaseLayerCreator) Create(image Image, _ DefinitionImage, _ SBOM) (L
 		return Layer{}, err
 	}
 
-	buffer, err := overwriteOsRelease(content, createOsReleasOverwrites(o.Def))
+	buffer, err := overwriteOsRelease(content, createOsReleaseOverwrites(o.Def))
 	if err != nil {
 		return Layer{}, err
 	}
@@ -72,7 +72,7 @@ func (o OsReleaseLayerCreator) Create(image Image, _ DefinitionImage, _ SBOM) (L
 	return tarToLayer(tarBuffer)
 }
 
-func createOsReleasOverwrites(def Definition) map[string]string {
+func createOsReleaseOverwrites(def Definition) map[string]string {
 	overwrites := map[string]string{}
 
 	if def.Name != "" {

--- a/internal/ihop/os_release_layer_creator.go
+++ b/internal/ihop/os_release_layer_creator.go
@@ -1,0 +1,104 @@
+package ihop
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// A OsReleaseLayerCreator can be used to construct a layer that includes /etc/os-release.
+type OsReleaseLayerCreator struct {
+	Def Definition
+}
+
+func (o OsReleaseLayerCreator) Create(image Image, _ DefinitionImage, _ SBOM) (Layer, error) {
+	img, err := image.ToDaemonImage()
+	if err != nil {
+		return Layer{}, err
+	}
+
+	tarBuffer, err := os.CreateTemp("", "")
+	if err != nil {
+		return Layer{}, err
+	}
+	defer tarBuffer.Close()
+	tw := tar.NewWriter(tarBuffer)
+
+	// find any existing /etc/ folder and copy the header
+	hdr, _, err := findFile(img, "etc/")
+	if err != nil {
+		return Layer{}, err
+	}
+	err = tw.WriteHeader(hdr)
+	if err != nil {
+		return Layer{}, err
+	}
+
+	// find any existing /etc/os-release file and copy the header
+	hdr, content, err := findFile(img, "etc/os-release")
+	if err != nil {
+		return Layer{}, err
+	}
+
+	buffer, err := updateOsRelease(content, o.Def)
+	if err != nil {
+		return Layer{}, err
+	}
+
+	err = tw.WriteHeader(&tar.Header{
+		Name: "etc/os-release",
+		Mode: hdr.Mode,
+		Size: int64(buffer.Len()),
+	})
+
+	if err != nil {
+		return Layer{}, err
+	}
+
+	_, err = io.Copy(tw, buffer)
+	if err != nil {
+		return Layer{}, err
+	}
+
+	err = tw.Close()
+	if err != nil {
+		return Layer{}, err
+	}
+
+	return tarToLayer(tarBuffer)
+}
+
+func updateOsRelease(content io.Reader, def Definition) (*bytes.Buffer, error) {
+	scanner := bufio.NewScanner(content)
+	updatedContent := map[string]string{}
+
+	for scanner.Scan() {
+		before, after, found := strings.Cut(scanner.Text(), "=")
+		if found {
+			updatedContent[before] = after
+		}
+	}
+	err := scanner.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	updatedContent["PRETTY_NAME"] = fmt.Sprintf("%q", def.Name)
+	updatedContent["HOME_URL"] = fmt.Sprintf("%q", def.Homepage)
+	updatedContent["SUPPORT_URL"] = fmt.Sprintf("%q", def.SupportURL)
+	updatedContent["BUG_REPORT_URL"] = fmt.Sprintf("%q", def.BugReportURL)
+
+	buffer := bytes.NewBuffer(nil)
+	for key, value := range updatedContent {
+		buffer.WriteString(key)
+		buffer.WriteString("=")
+		buffer.WriteString(value)
+		buffer.WriteString("\n")
+	}
+
+	return buffer, nil
+}

--- a/internal/ihop/os_release_layer_creator.go
+++ b/internal/ihop/os_release_layer_creator.go
@@ -4,9 +4,9 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -87,10 +87,10 @@ func updateOsRelease(content io.Reader, def Definition) (*bytes.Buffer, error) {
 		return nil, err
 	}
 
-	updatedContent["PRETTY_NAME"] = fmt.Sprintf("%q", def.Name)
-	updatedContent["HOME_URL"] = fmt.Sprintf("%q", def.Homepage)
-	updatedContent["SUPPORT_URL"] = fmt.Sprintf("%q", def.SupportURL)
-	updatedContent["BUG_REPORT_URL"] = fmt.Sprintf("%q", def.BugReportURL)
+	updatedContent["PRETTY_NAME"] = strconv.Quote(def.Name)
+	updatedContent["HOME_URL"] = strconv.Quote(def.Homepage)
+	updatedContent["SUPPORT_URL"] = strconv.Quote(def.SupportURL)
+	updatedContent["BUG_REPORT_URL"] = strconv.Quote(def.BugReportURL)
 
 	buffer := bytes.NewBuffer(nil)
 	for key, value := range updatedContent {

--- a/internal/ihop/os_release_layer_creator_test.go
+++ b/internal/ihop/os_release_layer_creator_test.go
@@ -27,7 +27,7 @@ func testOsReleaseLayerCreator(t *testing.T, context spec.G, it spec.S) {
 			BugReportURL: "some-stack-bug-report-url",
 		}
 		layer, err := creator.Create(
-			ihop.Image{Tag: "ubuntu:latest"},
+			ihop.Image{Tag: "ubuntu:jammy"},
 			ihop.DefinitionImage{},
 			ihop.SBOM{},
 		)

--- a/internal/ihop/os_release_layer_creator_test.go
+++ b/internal/ihop/os_release_layer_creator_test.go
@@ -1,0 +1,72 @@
+package ihop_test
+
+import (
+	"archive/tar"
+	"io"
+	"testing"
+
+	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testOsReleaseLayerCreator(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		creator ihop.OsReleaseLayerCreator
+	)
+
+	it("creates a layer with adjusted /etc/os-release", func() {
+		creator.Def = ihop.Definition{
+			ID:           "some-stack-id",
+			Name:         "some-stack-name",
+			Homepage:     "some-stack-homepage",
+			SupportURL:   "some-stack-support-url",
+			BugReportURL: "some-stack-bug-report-url",
+		}
+		layer, err := creator.Create(
+			ihop.Image{Tag: "ubuntu:latest"},
+			ihop.DefinitionImage{},
+			ihop.SBOM{},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		reader, err := layer.Uncompressed()
+		Expect(err).NotTo(HaveOccurred())
+		defer reader.Close()
+
+		tr := tar.NewReader(reader)
+		files := make(map[string]interface{})
+		headers := make(map[string]*tar.Header)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			var content interface{}
+			if hdr.Typeflag != tar.TypeDir {
+				b, err := io.ReadAll(tr)
+				Expect(err).NotTo(HaveOccurred())
+
+				content = string(b)
+			}
+
+			files[hdr.Name] = content
+			headers[hdr.Name] = hdr
+		}
+
+		Expect(files).To(SatisfyAll(
+			HaveLen(2),
+			HaveKeyWithValue("etc/", BeNil()),
+			HaveKeyWithValue("etc/os-release", ContainSubstring(`NAME="Ubuntu"`)),
+			HaveKeyWithValue("etc/os-release", ContainSubstring(`PRETTY_NAME="some-stack-name"`)),
+			HaveKeyWithValue("etc/os-release", ContainSubstring(`HOME_URL="some-stack-homepage"`)),
+			HaveKeyWithValue("etc/os-release", ContainSubstring(`SUPPORT_URL="some-stack-support-url"`)),
+			HaveKeyWithValue("etc/os-release", ContainSubstring(`BUG_REPORT_URL="some-stack-bug-report-url"`)),
+		))
+	})
+}

--- a/internal/ihop/sbom_layer_creator.go
+++ b/internal/ihop/sbom_layer_creator.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 // A SBOMLayerCreator can be used to construct a layer that includes the
@@ -67,18 +65,5 @@ func (c SBOMLayerCreator) Create(image Image, def DefinitionImage, sbom SBOM) (L
 		return Layer{}, err
 	}
 
-	layer, err := tarball.LayerFromFile(buffer.Name())
-	if err != nil {
-		return Layer{}, err
-	}
-
-	diffID, err := layer.DiffID()
-	if err != nil {
-		return Layer{}, err
-	}
-
-	return Layer{
-		DiffID: diffID.String(),
-		Layer:  layer,
-	}, nil
+	return tarToLayer(buffer)
 }


### PR DESCRIPTION
## Summary

This change fixes #82 by reading the necessary adjustments for `/etc/os-release` from `stack.toml`. It is based on two mandatory fields `name` (pretty name of the stack) and `homepage` (already included). The additionally introduced fields `support-url` and `bug-report-url` are defaulted off from `homepage`. This replicates the capabilities currently implemented as part of the run-image [Dockerfile](https://github.com/paketo-buildpacks/jammy-tiny-stack/blob/0ee5f28aaf767707840797b395c19c1a4d09809f/stack/run/run.Dockerfile#L35-L42) and a separate [os-release](https://github.com/paketo-buildpacks/jammy-tiny-stack/blob/main/stack/run/files/os-release) file. Afterwards the stacks should be updated accordingly.

## Use Cases

- Dynamically update `/etc/os-release` with data coming from `stack.toml`.

## Checklist

* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

CC @phil9909 