### PR TITLE
create stack: generate apt_preferences arg based on packages arg

### DIFF
--- a/internal/ihop/creator_test.go
+++ b/internal/ihop/creator_test.go
@@ -33,6 +33,46 @@ type layerCreateInvocation struct {
 	SBOM  ihop.SBOM
 }
 
+func testProcessArgs(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	context("packages arg is present", func() {
+		def := ihop.ProcessArgs(ihop.DefinitionImage{
+			Args: map[string]string{
+				"packages": "curl git jq ",
+			},
+		})
+
+		it("adds apt_preferences", func() {
+			Expect(def.Args).To(HaveLen(2))
+			Expect(def.Args).To(HaveKeyWithValue("apt_preferences", `Package: curl git jq
+Pin: release c=multiverse
+Pin-Priority: -1
+
+Package: curl git jq
+Pin: release c=restricted
+Pin-Priority: -1
+`))
+		})
+
+	})
+
+	context("packages arg is not present", func() {
+		def := ihop.ProcessArgs(ihop.DefinitionImage{
+			Args: map[string]string{
+				"something-else": "value",
+			},
+		})
+
+		it("does not modify args", func() {
+			Expect(def.Args).To(HaveLen(1))
+		})
+
+	})
+}
+
 func testCreator(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
@@ -319,8 +359,9 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Description: "some-stack-build-description",
 			Dockerfile:  "test-base-build-dockerfile-path",
 			Args: map[string]string{
-				"sources":  "test-sources",
-				"packages": "test-build-packages",
+				"sources":         "test-sources",
+				"packages":        "test-build-packages",
+				"apt_preferences": "Package: test-build-packages\nPin: release c=multiverse\nPin-Priority: -1\n\nPackage: test-build-packages\nPin: release c=restricted\nPin-Priority: -1\n",
 			},
 			UID: 1234,
 			GID: 2345,
@@ -330,8 +371,9 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Description: "some-stack-run-description",
 			Dockerfile:  "test-base-run-dockerfile-path",
 			Args: map[string]string{
-				"sources":  "test-sources",
-				"packages": "test-run-packages",
+				"sources":         "test-sources",
+				"packages":        "test-run-packages",
+				"apt_preferences": "Package: test-run-packages\nPin: release c=multiverse\nPin-Priority: -1\n\nPackage: test-run-packages\nPin: release c=restricted\nPin-Priority: -1\n",
 			},
 			UID: 3456,
 			GID: 4567,
@@ -345,8 +387,9 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Description: "some-stack-build-description",
 			Dockerfile:  "test-base-build-dockerfile-path",
 			Args: map[string]string{
-				"sources":  "test-sources",
-				"packages": "test-build-packages",
+				"sources":         "test-sources",
+				"packages":        "test-build-packages",
+				"apt_preferences": "Package: test-build-packages\nPin: release c=multiverse\nPin-Priority: -1\n\nPackage: test-build-packages\nPin: release c=restricted\nPin-Priority: -1\n",
 			},
 			UID: 1234,
 			GID: 2345,
@@ -358,8 +401,9 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Description: "some-stack-run-description",
 			Dockerfile:  "test-base-run-dockerfile-path",
 			Args: map[string]string{
-				"sources":  "test-sources",
-				"packages": "test-run-packages",
+				"sources":         "test-sources",
+				"packages":        "test-run-packages",
+				"apt_preferences": "Package: test-run-packages\nPin: release c=multiverse\nPin-Priority: -1\n\nPackage: test-run-packages\nPin: release c=restricted\nPin-Priority: -1\n",
 			},
 			UID: 3456,
 			GID: 4567,
@@ -739,8 +783,9 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				Description: "some-stack-run-description",
 				Dockerfile:  "test-base-run-dockerfile-path",
 				Args: map[string]string{
-					"sources":  "test-sources",
-					"packages": "test-run-packages",
+					"sources":         "test-sources",
+					"packages":        "test-run-packages",
+					"apt_preferences": "Package: test-run-packages\nPin: release c=multiverse\nPin-Priority: -1\n\nPackage: test-run-packages\nPin: release c=restricted\nPin-Priority: -1\n",
 				},
 				UID: 3456,
 				GID: 4567,

--- a/internal/ihop/init_test.go
+++ b/internal/ihop/init_test.go
@@ -40,6 +40,7 @@ func TestIHOP(t *testing.T) {
 	suite("Cataloger", testCataloger)
 	suite("Client", testClient)
 	suite("Creator", testCreator)
+	suite("ProcessArgs", testProcessArgs)
 	suite("Definition", testDefinition)
 	suite("Packages", testPackages)
 	suite("SBOM", testSBOM)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

See https://github.com/paketo-buildpacks/bionic-tiny-stack/issues/40#issuecomment-1227289130

To make it work in a stack, a change similar to this is required in the build and run Dockerfile:
```diff
--- a/stack/build.Dockerfile
+++ b/stack/build.Dockerfile
@@ -2,9 +2,11 @@ FROM ubuntu:jammy
 
 ARG sources
 ARG packages
+ARG apt_preferences
 ARG package_args='--no-install-recommends'
 
 RUN echo "$sources" > /etc/apt/sources.list
+RUN echo "$apt_preferences" > /etc/apt/preferences
 RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selections && \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get -y $package_args update && \

```

For proof-of-concept we just placed the code changes required for this somewhere in the creator. We are not sure, if this is the best location and if the function should be public at all. Any opinions on this?

## Use Cases

See https://github.com/paketo-buildpacks/bionic-tiny-stack/issues/40 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
      Note: Does not solve https://github.com/paketo-buildpacks/bionic-tiny-stack/issues/40 completely
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
