### PR TITLE
Add labeling workflow and release version workflow steps

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -16,3 +16,21 @@
 - name: documentation
   description: This issue relates to writing documentation
   color: D4C5F9
+- name: semver:major
+  description: A change requiring a major version bump
+  color: 6b230e
+- name: semver:minor
+  description: A change requiring a minor version bump
+  color: cc6749
+- name: semver:patch
+  description: A change requiring a patch version bump
+  color: f9d0c4
+- name: good first issue
+  description: A good first issue to get started with
+  color: d3fc03
+- name: "failure:release"
+  description: An issue filed automatically when a release workflow run fails
+  color: f00a0a
+- name: "failure:push"
+  description: An issue filed automatically when a push buildpackage workflow run fails
+  color: f00a0a

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
     - main
+    - v*
+  repository_dispatch:
+    types: [ version-bump ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of the release to cut (e.g. 1.2.3)'
+        required: false
+
+concurrency: release
 
 jobs:
   unit:
@@ -40,11 +50,22 @@ jobs:
       with:
         repo: ${{ github.repository }}
         token: ${{ github.token }}
-    - name: Tag
-      id: tag
-      uses: paketo-buildpacks/github-config/actions/tag/increment-tag@main
+    - name: Calculate Semver Tag
+      if: github.event.inputs.version == ''
+      id: semver
+      uses: paketo-buildpacks/github-config/actions/tag/calculate-semver@main
       with:
-        current_version: ${{ steps.reset.outputs.current_version }}
+        repo: ${{ github.repository }}
+        token: ${{ github.token }}
+        ref-name: ${{ github.ref_name }}
+    - name: Set Release Tag
+      id: tag
+      run: |
+        tag="${{ github.event.inputs.version }}"
+        if [ -z "${tag}" ]; then
+          tag="${{ steps.semver.outputs.tag }}"
+        fi
+        echo "::set-output name=tag::${tag}"
     - name: Package Jam
       run : ./scripts/package.sh --version ${{ steps.tag.outputs.tag }}
     - name: Create Draft Release
@@ -75,3 +96,21 @@ jobs:
             }
           ]
 
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-latest
+    needs: [ unit, release ]
+    if: ${{ always() && needs.unit.result == 'failure' || needs.release.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:release"
+        comment_if_exists: true
+        issue_title: "Failure: Create Draft Release workflow"
+        issue_body: |
+          Create Draft Release workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,34 @@
+name: Set / Validate PR Labels
+on:
+  pull_request_target:
+    branches:
+    - main
+    - v*
+    types:
+    - synchronize
+    - opened
+    - reopened
+    - labeled
+    - unlabeled
+
+concurrency: pr_labels_${{ github.event.number }}
+
+jobs:
+  autolabel:
+    name: Ensure Minimal Semver Labels
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Minimal Semver Labels
+      uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: semver:major, semver:minor, semver:patch
+        mode: exactly
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Auto-label Semver
+      if: ${{ failure() }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/auto-semver-label@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Add labeling workflow to auto-label/ensure semver labels are added to PRs, and also add steps to release draft workflow to use PR labels to calculate release version.

The `jam` workflows have enough differences from the [github-config library workflows](https://github.com/paketo-buildpacks/github-config/tree/main/library) its easier not to add in automated github-config update here

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
