### PR TITLE
fix validation workflow output path

### DIFF
--- a/.github/workflows/validate-release-version.yml
+++ b/.github/workflows/validate-release-version.yml
@@ -20,7 +20,7 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/release/download-asset@main
       with:
         url: ${{ steps.event.outputs.download_url }}
-        output: "$GITHUB_WORKSPACE/jam"
+        output: "/github/workspace/jam"
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
     - name: Validate version
       run: |


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR updates the `output` path that `jam` is downloaded to in the asset validation workflow. The workflow is still failing, due to `jam` not being found. See https://github.com/paketo-buildpacks/jam/actions/runs/3108359372

This is because the output path in the download step is `$GITHUB_WORKSPACE/jam`, but `$GITHUB_WORKSPACE` isn't set on the action container. 
The download action `docker run` runs with `-v "/home/runner/work/jam/jam":"/github/workspace"`, and `$GITHUB_WORKSPACE` is equal to `home/runner/work/jam/jam`. We need to install to `/github/workspace` instead so that volume mounting works correctly.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
