### PR TITLE
Allow slices and integers as a value for arguments in the DefinitionImage struct

### DIFF
--- a/internal/ihop/client.go
+++ b/internal/ihop/client.go
@@ -189,9 +189,13 @@ func (c Client) Build(def DefinitionImage, platform string) (Image, error) {
 	}
 	tag = fmt.Sprintf("paketo.io/stack/%s", tag)
 
+	buildArgs, err := def.Arguments()
+	if err != nil {
+		return Image{}, err
+	}
 	// send a request to the Docker daemon to build the image
 	resp, err := c.docker.ImageBuild(context.Background(), buildContext, types.ImageBuildOptions{
-		BuildArgs:  opts.ConvertKVStringsToMapWithNil(def.Arguments()),
+		BuildArgs:  opts.ConvertKVStringsToMapWithNil(buildArgs),
 		Dockerfile: relDockerfile,
 		NoCache:    true,
 		Remove:     true,

--- a/internal/ihop/creator_test.go
+++ b/internal/ihop/creator_test.go
@@ -249,7 +249,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Build: ihop.DefinitionImage{
 				Description: "some-stack-build-description",
 				Dockerfile:  "test-base-build-dockerfile-path",
-				Args: map[string]string{
+				Args: map[string]any{
 					"sources":  "test-sources",
 					"packages": "test-build-packages",
 				},
@@ -259,7 +259,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Run: ihop.DefinitionImage{
 				Description: "some-stack-run-description",
 				Dockerfile:  "test-base-run-dockerfile-path",
-				Args: map[string]string{
+				Args: map[string]any{
 					"sources":  "test-sources",
 					"packages": "test-run-packages",
 				},
@@ -330,7 +330,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 		Expect(imageBuildInvocations[0].Def).To(Equal(ihop.DefinitionImage{
 			Description: "some-stack-build-description",
 			Dockerfile:  "test-base-build-dockerfile-path",
-			Args: map[string]string{
+			Args: map[string]any{
 				"sources":  "test-sources",
 				"packages": "test-build-packages",
 			},
@@ -341,7 +341,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 		Expect(imageBuildInvocations[1].Def).To(Equal(ihop.DefinitionImage{
 			Description: "some-stack-run-description",
 			Dockerfile:  "test-base-run-dockerfile-path",
-			Args: map[string]string{
+			Args: map[string]any{
 				"sources":  "test-sources",
 				"packages": "test-run-packages",
 			},
@@ -356,7 +356,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 		Expect(userLayerCreateInvocations[0].Def).To(Equal(ihop.DefinitionImage{
 			Description: "some-stack-build-description",
 			Dockerfile:  "test-base-build-dockerfile-path",
-			Args: map[string]string{
+			Args: map[string]any{
 				"sources":  "test-sources",
 				"packages": "test-build-packages",
 			},
@@ -369,7 +369,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 		Expect(userLayerCreateInvocations[1].Def).To(Equal(ihop.DefinitionImage{
 			Description: "some-stack-run-description",
 			Dockerfile:  "test-base-run-dockerfile-path",
-			Args: map[string]string{
+			Args: map[string]any{
 				"sources":  "test-sources",
 				"packages": "test-run-packages",
 			},
@@ -588,7 +588,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				Build: ihop.DefinitionImage{
 					Description: "some-stack-build-description",
 					Dockerfile:  "test-base-build-dockerfile-path",
-					Args: map[string]string{
+					Args: map[string]any{
 						"sources":  "test-sources",
 						"packages": "test-build-packages",
 					},
@@ -596,7 +596,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				Run: ihop.DefinitionImage{
 					Description: "some-stack-run-description",
 					Dockerfile:  "test-base-run-dockerfile-path",
-					Args: map[string]string{
+					Args: map[string]any{
 						"sources":  "test-sources",
 						"packages": "test-run-packages",
 					},
@@ -669,7 +669,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				Build: ihop.DefinitionImage{
 					Description: "some-stack-build-description",
 					Dockerfile:  "test-base-build-dockerfile-path",
-					Args: map[string]string{
+					Args: map[string]any{
 						"sources":  "test-sources",
 						"packages": "test-build-packages",
 					},
@@ -677,7 +677,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				Run: ihop.DefinitionImage{
 					Description: "some-stack-run-description",
 					Dockerfile:  "test-base-run-dockerfile-path",
-					Args: map[string]string{
+					Args: map[string]any{
 						"sources":  "test-sources",
 						"packages": "test-run-packages",
 					},
@@ -712,7 +712,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				Build: ihop.DefinitionImage{
 					Description: "some-stack-build-description",
 					Dockerfile:  "test-base-build-dockerfile-path",
-					Args: map[string]string{
+					Args: map[string]any{
 						"sources":  "test-sources",
 						"packages": "test-build-packages",
 					},
@@ -722,7 +722,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				Run: ihop.DefinitionImage{
 					Description: "some-stack-run-description",
 					Dockerfile:  "test-base-run-dockerfile-path",
-					Args: map[string]string{
+					Args: map[string]any{
 						"sources":  "test-sources",
 						"packages": "test-run-packages",
 					},
@@ -762,7 +762,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Expect(sbomLayerCreateInvocations[0].Def).To(Equal(ihop.DefinitionImage{
 				Description: "some-stack-run-description",
 				Dockerfile:  "test-base-run-dockerfile-path",
-				Args: map[string]string{
+				Args: map[string]any{
 					"sources":  "test-sources",
 					"packages": "test-run-packages",
 				},

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -105,18 +105,18 @@ func (i DefinitionImage) Arguments() ([]string, error) {
 		case []string:
 			v = strings.Join(valTyped, " ")
 		case []any:
-			typedSlince := make([]string, len(valTyped))
+			typedSlice := make([]string, len(valTyped))
 			for i, e := range valTyped {
 				switch elementTyped := e.(type) {
 				case string:
-					typedSlince[i] = elementTyped
+					typedSlice[i] = elementTyped
 				case int, int64, int32, int16, int8:
-					typedSlince[i] = fmt.Sprintf("%d", elementTyped)
+					typedSlice[i] = fmt.Sprintf("%d", elementTyped)
 				default:
 					return nil, fmt.Errorf("unsupported type %T for the argument element %q.%d", elementTyped, key, i)
 				}
 			}
-			v = strings.Join(typedSlince, " ")
+			v = strings.Join(typedSlice, " ")
 		default:
 			return nil, fmt.Errorf("unsupported type %T for the argument %q", valTyped, key)
 		}

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -387,6 +387,36 @@ homepage = "https://github.com/some-stack"
 				})
 			})
 
+			context("when slice contains unsupported types", func() {
+				it.Before(func() {
+					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
+id = "some-stack-id"
+name = "some-stack-name"
+homepage = "https://github.com/some-stack"
+
+[build]
+	dockerfile = "some-build-dockerfile"
+	uid = 1234
+	gid = 2345
+	[build.args]
+		key = [false]
+[run]
+	dockerfile = "some-run-dockerfile"
+	uid = 1234
+	gid = 2345
+`), 0600)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("returns an error", func() {
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = definition.Build.Arguments()
+					Expect(err).To(MatchError("unsupported type bool for the argument element \"key\".0"))
+				})
+			})
+
 			context("when arg is a map", func() {
 				it.Before(func() {
 					err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->

This PR introduces backward compatible support for lists of strings/integers as a value type for the docker build arguments.

## Use Cases
<!-- An explanation of the use cases your change enables -->

This opens a possibility to integrate stack's image dependencies to be managed by tools like [Renovate](https://docs.renovatebot.com/) and it's `repology` datasource. For example, the `stack.toml` can be changed in the following way:

```toml
  [run.args]
    packages = [
      # renovate: depName=bash
      "bash=5.0-6ubuntu1",
      # renovate: depName=dash
      "dash=0.5.11+git20210903+057cd650a4ed-3build1",
      # renovate: depName=ca-certificates
      "ca-certificates=20211016",
      # renovate: depName=glibc
      "libc6=2.35-0ubuntu3",
      # renovate: depName=gcc-12
      "libgcc-s1=12.0.0-2ubuntu1~22.04",
      # renovate: depName=openssl
      "libssl3=3.0.2-0ubuntu1.6",
      # renovate: depName=gcc-12
      "libstdc++6=12.0.0-2ubuntu1~22.04",
      # renovate: depName=zlib
      "zlib1g=1:1.2.11.dfsg-2ubuntu9"
    ]
```

And configure `regexManager` in the renovate config:

```json
  "regexManagers": [
    {
      "fileMatch": [
        "^stack\\/stack\\.toml$"
      ],
      "matchStrings": [
        "# renovate: depName=(?<depName>.*?)\\s+.*?\\=(?<currentValue>.*?)\""
      ],
      "datasourceTemplate": "repology",
      "versioningTemplate": "loose",
      "depNameTemplate": "ubuntu_22_04/{{{depName}}}"
    }
  ],
```

With the changes above, it's no longer necessary to perform scheduled builds, since all the dependencies are of a specific version with bumps coming through PRs from renovate.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
