### PR TITLE
initial create-stack-descriptor sub-command

### DIFF
--- a/commands/create_stack_descriptor.go
+++ b/commands/create_stack_descriptor.go
@@ -1,0 +1,137 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(createStackDescriptor())
+}
+
+type createStackDescriptorFlags struct {
+	output         string
+	nonInteractive bool
+}
+
+func createStackDescriptor() *cobra.Command {
+	flags := &createStackDescriptorFlags{}
+	cmd := &cobra.Command{
+		Use:   "create-stack-descriptor",
+		Short: "create-stack-descriptor",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createStackDescriptorRun(*flags)
+		},
+	}
+	cmd.Flags().StringVar(&flags.output, "output", "stack.toml", "target path for the generated stack.toml")
+	cmd.Flags().BoolVar(&flags.nonInteractive, "non-interactive", false, "do not ask for input")
+
+	return cmd
+}
+
+const tomlTemplate = `id = "{{ .ID }}"
+homepage = "{{ .Homepage }}"
+maintainer = "{{ .Maintainer }}"
+
+platforms = ["linux/amd64"]
+
+[build]
+  description = "{{ .RunImageDescription }}"
+  dockerfile = "./build.Dockerfile"
+  gid = 1000
+  shell = "/bin/bash"
+  uid = 1001
+
+[run]
+  description = "{{ .BuildImageDescription }}"
+  dockerfile = "./run.Dockerfile"
+  gid = 1000
+  shell = "/sbin/nologin"
+  uid = 1002
+`
+
+type templateInput struct {
+	ID                    string
+	Homepage              string
+	Maintainer            string
+	RunImageDescription   string
+	BuildImageDescription string
+}
+
+func readString(prompt string, fallback string, reader *bufio.Reader) (string, error) {
+	fmt.Printf("%s (default %q): ", prompt, fallback)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	line = strings.Trim(line, "\n")
+	if line == "" {
+		return fallback, nil
+	}
+	return line, nil
+}
+
+func createStackDescriptorRun(flags createStackDescriptorFlags) error {
+	input := templateInput{
+		ID:                    "com.example.mystack",
+		Homepage:              "https://www.example.com/mystack",
+		Maintainer:            "Example Inc.",
+		RunImageDescription:   "RunImage for example apps",
+		BuildImageDescription: "BuildImage for example apps",
+	}
+	var err error
+
+	if !flags.nonInteractive {
+		reader := bufio.NewReader(os.Stdin)
+
+		input.ID, err = readString("Stack ID", input.ID, reader)
+		if err != nil {
+			return err
+		}
+
+		input.Homepage, err = readString("Homepage", input.Homepage, reader)
+		if err != nil {
+			return err
+		}
+
+		input.Maintainer, err = readString("Maintainer", input.Maintainer, reader)
+		if err != nil {
+			return err
+		}
+
+		input.RunImageDescription, err = readString("Run Image Description", input.RunImageDescription, reader)
+		if err != nil {
+			return err
+		}
+
+		input.BuildImageDescription, err = readString("Build Image Description", input.BuildImageDescription, reader)
+		if err != nil {
+			return err
+		}
+	}
+
+	var output io.Writer
+	if flags.output == "-" {
+		output = os.Stdout
+	} else {
+		file, err := os.OpenFile(flags.output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		output = file
+	}
+
+	tmpl := template.Must(template.New("stack.toml").Parse(tomlTemplate))
+	err = tmpl.Execute(output, input)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Obviously this misses some things like tests, but I wanted early feedback, if this is the right direction.

Example run:

```console
$ ./jam create-stack-descriptor --help
create-stack-descriptor

Usage:
  jam create-stack-descriptor [flags]

Flags:
  -h, --help              help for create-stack-descriptor
      --non-interactive   do not ask for input
      --output string     target path for the generated stack.toml (default "stack.toml")

$ ./jam create-stack-descriptor
Stack ID (default "com.example.mystack"): 
Homepage (default "https://www.example.com/mystack"): 
Maintainer (default "Example Inc."): 
Run Image Description (default "RunImage for example apps"): My Awesome RunImage
Build Image Description (default "BuildImage for example apps"): My Awesome BuildImage 

$ cat stack.toml 
id = "com.example.mystack"
homepage = "https://www.example.com/mystack"
maintainer = "Example Inc."

platforms = ["linux/amd64"]

[build]
  description = "My Awesome RunImage"
  dockerfile = "./build.Dockerfile"
  gid = 1000
  shell = "/bin/bash"
  uid = 1001

[run]
  description = "My Awesome BuildImage"
  dockerfile = "./run.Dockerfile"
  gid = 1000
  shell = "/sbin/nologin"
  uid = 1002
```

Using the `--non-interactive` flag will disable stdin prompts and use default values instead.

## Use Cases

Fixes https://github.com/paketo-buildpacks/jam/issues/56

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
