### PR TITLE
Improve create-stack build time by using OCI layout

### DIFF
--- a/integration/create_stack_test.go
+++ b/integration/create_stack_test.go
@@ -261,7 +261,6 @@ func testCreateStack(t *testing.T, _ spec.G, it spec.S) {
 				"",
 				fmt.Sprintf("  Exporting build image to %s", filepath.Join(tmpDir, "build.oci")),
 				fmt.Sprintf("  Exporting run image to %s", filepath.Join(tmpDir, "run.oci")),
-				"  Cleaning up intermediate image artifacts",
 			))
 		})
 	})

--- a/internal/fakes/downloader.go
+++ b/internal/fakes/downloader.go
@@ -7,7 +7,7 @@ import (
 
 type Downloader struct {
 	DropCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Root string
@@ -22,8 +22,8 @@ type Downloader struct {
 }
 
 func (f *Downloader) Drop(param1 string, param2 string) (io.ReadCloser, error) {
-	f.DropCall.Lock()
-	defer f.DropCall.Unlock()
+	f.DropCall.mutex.Lock()
+	defer f.DropCall.mutex.Unlock()
 	f.DropCall.CallCount++
 	f.DropCall.Receives.Root = param1
 	f.DropCall.Receives.Uri = param2

--- a/internal/fakes/executable.go
+++ b/internal/fakes/executable.go
@@ -8,7 +8,7 @@ import (
 
 type Executable struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Execution pexec.Execution
@@ -21,8 +21,8 @@ type Executable struct {
 }
 
 func (f *Executable) Execute(param1 pexec.Execution) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Execution = param1
 	if f.ExecuteCall.Stub != nil {

--- a/internal/ihop/builder.go
+++ b/internal/ihop/builder.go
@@ -2,7 +2,7 @@ package ihop
 
 //go:generate faux --interface ImageScanner --output fakes/image_scanner.go
 type ImageScanner interface {
-	Scan(tag string) (SBOM, error)
+	Scan(path string) (SBOM, error)
 }
 
 //go:generate faux --interface ImageBuildPromise --output fakes/image_build_promise.go
@@ -63,7 +63,7 @@ func (b Builder) build(def DefinitionImage, platform string) (Image, SBOM, error
 		return Image{}, SBOM{}, err
 	}
 
-	sbom, err := b.scanner.Scan(image.Tag)
+	sbom, err := b.scanner.Scan(image.Path)
 	if err != nil {
 		return Image{}, SBOM{}, err
 	}

--- a/internal/ihop/builder_test.go
+++ b/internal/ihop/builder_test.go
@@ -24,7 +24,7 @@ func testBuilder(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		client = &fakes.ImageClient{}
-		client.BuildCall.Returns.Image = ihop.Image{Tag: "some-image-tag"}
+		client.BuildCall.Returns.Image = ihop.Image{Path: "some-image-path"}
 
 		scanner = &fakes.ImageScanner{}
 		scanner.ScanCall.Returns.SBOM = ihop.NewSBOM(sbom.SBOM{
@@ -44,7 +44,7 @@ func testBuilder(t *testing.T, context spec.G, it spec.S) {
 		image, bom, err := promise.Resolve()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(image).To(Equal(ihop.Image{
-			Tag: "some-image-tag",
+			Path: "some-image-path",
 		}))
 		Expect(bom).To(Equal(ihop.NewSBOM(sbom.SBOM{
 			Artifacts: sbom.Artifacts{
@@ -59,7 +59,7 @@ func testBuilder(t *testing.T, context spec.G, it spec.S) {
 		Expect(client.BuildCall.Receives.Platform).To(Equal("some-platform"))
 
 		Expect(scanner.ScanCall.CallCount).To(Equal(1))
-		Expect(scanner.ScanCall.Receives.Tag).To(Equal("some-image-tag"))
+		Expect(scanner.ScanCall.Receives.Path).To(Equal("some-image-path"))
 	})
 
 	context("failure cases", func() {

--- a/internal/ihop/cataloger.go
+++ b/internal/ihop/cataloger.go
@@ -14,8 +14,8 @@ import (
 type Cataloger struct{}
 
 // Scan generates an SBOM for an image tagged in the Docker daemon.
-func (c Cataloger) Scan(tag string) (SBOM, error) {
-	input, err := source.ParseInput(fmt.Sprintf("docker:%s", tag), "", false)
+func (c Cataloger) Scan(path string) (SBOM, error) {
+	input, err := source.ParseInput(fmt.Sprintf("oci-dir:%s", path), "", false)
 	if err != nil {
 		return SBOM{}, err
 	}

--- a/internal/ihop/creator_test.go
+++ b/internal/ihop/creator_test.go
@@ -75,7 +75,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			imageUpdateInvocations = append(imageUpdateInvocations, imageUpdateInvocation{
 				Image: ihop.Image{
 					Digest: image.Digest,
-					Tag:    image.Tag,
 					Layers: image.Layers,
 					User:   image.User,
 					Env:    append([]string{}, image.Env...),
@@ -161,7 +160,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			promise := &fakes.ImageBuildPromise{}
 			promise.ResolveCall.Returns.Image = ihop.Image{
 				Digest: imageDigest(),
-				Tag:    fmt.Sprintf("image-%d", imageBuilder.ExecuteCall.CallCount),
 				Labels: map[string]string{},
 			}
 			promise.ResolveCall.Returns.SBOM = sboms[imageBuilder.ExecuteCall.CallCount-1]
@@ -179,7 +177,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			userLayerCreateInvocations = append(userLayerCreateInvocations, layerCreateInvocation{
 				Image: ihop.Image{
 					Digest: image.Digest,
-					Tag:    image.Tag,
 					Layers: image.Layers,
 					User:   image.User,
 					Env:    append([]string{}, image.Env...),
@@ -209,7 +206,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			sbomLayerCreateInvocations = append(sbomLayerCreateInvocations, layerCreateInvocation{
 				Image: ihop.Image{
 					Digest: image.Digest,
-					Tag:    image.Tag,
 					Layers: image.Layers,
 					User:   image.User,
 					Env:    append([]string{}, image.Env...),
@@ -271,7 +267,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 		Expect(stack).To(Equal(ihop.Stack{
 			Build: []ihop.Image{
 				{
-					Tag:    "image-1",
 					Digest: "image-digest-3",
 					User:   "1234:2345",
 					Env: []string{
@@ -299,7 +294,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			},
 			Run: []ihop.Image{
 				{
-					Tag:    "image-2",
 					Digest: "image-digest-4",
 					User:   "3456:4567",
 					Labels: map[string]string{
@@ -352,7 +346,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(userLayerCreator.CreateCall.CallCount).To(Equal(2))
 		Expect(userLayerCreateInvocations[0].Image.Digest).To(Equal("image-digest-1"))
-		Expect(userLayerCreateInvocations[0].Image.Tag).To(Equal("image-1"))
 		Expect(userLayerCreateInvocations[0].Def).To(Equal(ihop.DefinitionImage{
 			Description: "some-stack-build-description",
 			Dockerfile:  "test-base-build-dockerfile-path",
@@ -365,7 +358,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 		}))
 		Expect(userLayerCreateInvocations[0].SBOM).To(Equal(buildSBOM))
 		Expect(userLayerCreateInvocations[1].Image.Digest).To(Equal("image-digest-2"))
-		Expect(userLayerCreateInvocations[1].Image.Tag).To(Equal("image-2"))
 		Expect(userLayerCreateInvocations[1].Def).To(Equal(ihop.DefinitionImage{
 			Description: "some-stack-run-description",
 			Dockerfile:  "test-base-run-dockerfile-path",
@@ -380,7 +372,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(imageClient.UpdateCall.CallCount).To(Equal(2))
 		Expect(imageUpdateInvocations[0].Image.Digest).To(Equal("image-digest-1"))
-		Expect(imageUpdateInvocations[0].Image.Tag).To(Equal("image-1"))
 		Expect(imageUpdateInvocations[0].Image.Labels).To(SatisfyAll(
 			HaveKeyWithValue("io.buildpacks.stack.id", "some-stack-id"),
 			HaveKeyWithValue("io.buildpacks.stack.description", "some-stack-build-description"),
@@ -405,7 +396,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			"CNB_STACK_ID=some-stack-id",
 		))
 		Expect(imageUpdateInvocations[1].Image.Digest).To(Equal("image-digest-2"))
-		Expect(imageUpdateInvocations[1].Image.Tag).To(Equal("image-2"))
 		Expect(imageUpdateInvocations[1].Image.Labels).To(SatisfyAll(
 			HaveKeyWithValue("io.buildpacks.stack.id", "some-stack-id"),
 			HaveKeyWithValue("io.buildpacks.stack.description", "some-stack-run-description"),
@@ -449,7 +439,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Expect(stack).To(Equal(ihop.Stack{
 				Build: []ihop.Image{
 					{
-						Tag:    "image-1",
 						Digest: "image-digest-3",
 						User:   "1234:2345",
 						Env: []string{
@@ -475,7 +464,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					{
-						Tag:    "image-3",
 						Digest: "image-digest-7",
 						User:   "1234:2345",
 						Env: []string{
@@ -503,7 +491,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				},
 				Run: []ihop.Image{
 					{
-						Tag:    "image-2",
 						Digest: "image-digest-4",
 						User:   "3456:4567",
 						Labels: map[string]string{
@@ -528,7 +515,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					{
-						Tag:    "image-4",
 						Digest: "image-digest-8",
 						User:   "3456:4567",
 						Labels: map[string]string{
@@ -606,7 +592,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(imageClient.UpdateCall.CallCount).To(Equal(2))
 			Expect(imageUpdateInvocations[0].Image.Digest).To(Equal("image-digest-1"))
-			Expect(imageUpdateInvocations[0].Image.Tag).To(Equal("image-1"))
 			Expect(imageUpdateInvocations[0].Image.Labels).To(HaveKeyWithValue("io.paketo.stack.packages", MatchJSON(`[
  				{
 					"name": "some-build-package",
@@ -630,7 +615,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				}
 			]`)))
 			Expect(imageUpdateInvocations[1].Image.Digest).To(Equal("image-digest-2"))
-			Expect(imageUpdateInvocations[1].Image.Tag).To(Equal("image-2"))
 			Expect(imageUpdateInvocations[1].Image.Labels).To(HaveKeyWithValue("io.paketo.stack.packages", MatchJSON(`[
 				{
 					"name": "some-common-package",
@@ -688,11 +672,9 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			Expect(imageClient.UpdateCall.CallCount).To(Equal(2))
 
 			Expect(imageUpdateInvocations[0].Image.Digest).To(Equal("image-digest-1"))
-			Expect(imageUpdateInvocations[0].Image.Tag).To(Equal("image-1"))
 			Expect(imageUpdateInvocations[0].Image.Labels).To(HaveKeyWithValue("io.buildpacks.stack.mixins", MatchJSON(`["some-common-package","build:some-build-package"]`)))
 
 			Expect(imageUpdateInvocations[1].Image.Digest).To(Equal("image-digest-2"))
-			Expect(imageUpdateInvocations[1].Image.Tag).To(Equal("image-2"))
 			Expect(imageUpdateInvocations[1].Image.Labels).To(HaveKeyWithValue("io.buildpacks.stack.mixins", MatchJSON(`["some-common-package","run:some-run-package"]`)))
 		})
 	})
@@ -737,13 +719,11 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(imageClient.UpdateCall.CallCount).To(Equal(2))
 			Expect(imageUpdateInvocations[0].Image.Digest).To(Equal("image-digest-1"))
-			Expect(imageUpdateInvocations[0].Image.Tag).To(Equal("image-1"))
 			Expect(imageUpdateInvocations[0].Image.Labels).NotTo(HaveKey("io.buildpacks.base.sbom"))
 			Expect(imageUpdateInvocations[0].Image.Layers).To(Equal([]ihop.Layer{
 				{DiffID: "build-user-layer-id"},
 			}))
 			Expect(imageUpdateInvocations[1].Image.Digest).To(Equal("image-digest-2"))
-			Expect(imageUpdateInvocations[1].Image.Tag).To(Equal("image-2"))
 			Expect(imageUpdateInvocations[1].Image.Labels).To(HaveKeyWithValue("io.buildpacks.base.sbom", "sbom-layer-id"))
 			Expect(imageUpdateInvocations[1].Image.Layers).To(Equal([]ihop.Layer{
 				{DiffID: "run-user-layer-id"},
@@ -753,7 +733,6 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(sbomLayerCreator.CreateCall.CallCount).To(Equal(1))
 			Expect(sbomLayerCreateInvocations[0].Image.Digest).To(Equal("image-digest-2"))
-			Expect(sbomLayerCreateInvocations[0].Image.Tag).To(Equal("image-2"))
 			Expect(sbomLayerCreateInvocations[0].Image.Labels).NotTo(HaveKey("io.buildpacks.base.sbom"))
 			Expect(sbomLayerCreateInvocations[0].Image.Layers).To(Equal([]ihop.Layer{
 				{DiffID: "run-user-layer-id"},

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -75,8 +75,6 @@ type DefinitionImage struct {
 
 	// UID is the cnb user id to be specified in the image.
 	UID int `toml:"uid"`
-
-	unbuffered bool
 }
 
 // DefinitionDeprecated defines the deprecated features of the stack.
@@ -128,7 +126,7 @@ func (i DefinitionImage) Arguments() ([]string, error) {
 }
 
 // NewDefinitionFromFile parses the stack descriptor from a file location.
-func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Definition, error) {
+func NewDefinitionFromFile(path string, secrets ...string) (Definition, error) {
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return Definition{}, err
@@ -219,9 +217,6 @@ func NewDefinitionFromFile(path string, unbuffered bool, secrets ...string) (Def
 
 		definition.Run.Secrets = definition.Build.Secrets
 	}
-
-	definition.Build.unbuffered = unbuffered
-	definition.Run.unbuffered = unbuffered
 
 	return definition, nil
 }

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -67,7 +67,7 @@ platforms = ["some-stack-platform"]
 		})
 
 		it("creates a definition from a config file", func() {
-			definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+			definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(definition).To(Equal(ihop.Definition{
 				ID:           "some-stack-id",
@@ -126,7 +126,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("sets the defaults", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(definition).To(Equal(ihop.Definition{
 						ID:           "some-stack-id",
@@ -173,7 +173,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'id' is a required field"))
 				})
 			})
@@ -198,7 +198,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.dockerfile' is a required field"))
 				})
 			})
@@ -223,7 +223,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.uid' is a required field"))
 				})
 			})
@@ -249,7 +249,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.gid' is a required field"))
 				})
 			})
@@ -274,7 +274,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.dockerfile' is a required field"))
 				})
 			})
@@ -299,7 +299,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.uid' is a required field"))
 				})
 			})
@@ -324,7 +324,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.gid' is a required field"))
 				})
 			})
@@ -332,7 +332,7 @@ homepage = "some-stack-homepage"
 
 		context("when secrets are given", func() {
 			it("includes them in the build/run image definitions", func() {
-				definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false, "first-secret=first-value", "second-secret=second-value")
+				definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), "first-secret=first-value", "second-secret=second-value")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(definition.Build.Secrets).To(Equal(map[string]string{
 					"first-secret":  "first-value",
@@ -375,7 +375,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("transforms args to string", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).NotTo(HaveOccurred())
 					buildArgs, err := definition.Build.Arguments()
 					Expect(err).NotTo(HaveOccurred())
@@ -409,7 +409,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("returns an error", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).ToNot(HaveOccurred())
 
 					_, err = definition.Build.Arguments()
@@ -446,7 +446,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("returns an error", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).ToNot(HaveOccurred())
 
 					buildArgs, err := definition.Build.Arguments()
@@ -462,7 +462,7 @@ homepage = "https://github.com/some-stack"
 		context("failure cases", func() {
 			context("when the file cannot be opened", func() {
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile("this file does not exist", false)
+					_, err := ihop.NewDefinitionFromFile("this file does not exist")
 					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 				})
 			})
@@ -474,14 +474,14 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
 					Expect(err).To(MatchError(ContainSubstring("but got '%' instead")))
 				})
 			})
 
 			context("when a secret is malformed", func() {
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false, "this secret is malformed")
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), "this secret is malformed")
 					Expect(err).To(MatchError("malformed secret: \"this secret is malformed\" must be in the form \"key=value\""))
 				})
 			})

--- a/internal/ihop/fakes/image_scanner.go
+++ b/internal/ihop/fakes/image_scanner.go
@@ -11,7 +11,7 @@ type ImageScanner struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			Tag string
+			Path string
 		}
 		Returns struct {
 			SBOM  ihop.SBOM
@@ -25,7 +25,7 @@ func (f *ImageScanner) Scan(param1 string) (ihop.SBOM, error) {
 	f.ScanCall.mutex.Lock()
 	defer f.ScanCall.mutex.Unlock()
 	f.ScanCall.CallCount++
-	f.ScanCall.Receives.Tag = param1
+	f.ScanCall.Receives.Path = param1
 	if f.ScanCall.Stub != nil {
 		return f.ScanCall.Stub(param1)
 	}

--- a/internal/ihop/init_test.go
+++ b/internal/ihop/init_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestIHOP(t *testing.T) {
+func TestUnitIHOP(t *testing.T) {
 	format.MaxLength = 0
 	var Expect = NewWithT(t).Expect
 

--- a/internal/ihop/os_release_layer_creator.go
+++ b/internal/ihop/os_release_layer_creator.go
@@ -16,10 +16,7 @@ type OsReleaseLayerCreator struct {
 }
 
 func (o OsReleaseLayerCreator) Create(image Image, _ DefinitionImage, _ SBOM) (Layer, error) {
-	img, err := image.ToDaemonImage()
-	if err != nil {
-		return Layer{}, err
-	}
+	img := image.Actual
 
 	tarBuffer, err := os.CreateTemp("", "")
 	if err != nil {

--- a/internal/ihop/os_release_layer_creator_test.go
+++ b/internal/ihop/os_release_layer_creator_test.go
@@ -3,6 +3,8 @@ package ihop_test
 import (
 	"archive/tar"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/paketo-buildpacks/jam/internal/ihop"
@@ -16,7 +18,31 @@ func testOsReleaseLayerCreator(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		creator ihop.OsReleaseLayerCreator
+		client  ihop.Client
+		image   ihop.Image
+		dir     string
 	)
+
+	it.Before(func() {
+		var err error
+		dir, err = os.MkdirTemp("", "dockerfile-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		client, err = ihop.NewClient(dir)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM ubuntu:jammy\nUSER some-user:some-group"), 0600)
+		Expect(err).NotTo(HaveOccurred())
+
+		image, err = client.Build(ihop.DefinitionImage{
+			Dockerfile: filepath.Join(dir, "Dockerfile"),
+		}, "linux/amd64")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(dir)).To(Succeed())
+	})
 
 	it("creates a layer with adjusted /etc/os-release", func() {
 		creator.Def = ihop.Definition{
@@ -27,7 +53,7 @@ func testOsReleaseLayerCreator(t *testing.T, context spec.G, it spec.S) {
 			BugReportURL: "some-stack-bug-report-url",
 		}
 		layer, err := creator.Create(
-			ihop.Image{Tag: "ubuntu:jammy"},
+			image,
 			ihop.DefinitionImage{},
 			ihop.SBOM{},
 		)

--- a/internal/ihop/sbom_test.go
+++ b/internal/ihop/sbom_test.go
@@ -118,7 +118,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			Expect(output).To(MatchJSON(`{
 				"artifacts": [
 					{
-						"id": "ad6a28f75514e659",
+						"id": "f0dc33bc5d7603be",
 						"name": "a-package",
 						"version": "",
 						"type": "",
@@ -147,7 +147,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 						}
 					},
 					{
-						"id": "99337f6e42516f6f",
+						"id": "3967142b5e338b90",
 						"name": "b-package",
 						"version": "",
 						"type": "",
@@ -173,7 +173,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 						}
 					},
 					{
-						"id": "e9f5fdd345ca49fd",
+						"id": "3ffc024cc467d6f2",
 						"name": "c-package",
 						"version": "",
 						"type": "",

--- a/internal/ihop/user_layer_creator.go
+++ b/internal/ihop/user_layer_creator.go
@@ -16,10 +16,7 @@ type UserLayerCreator struct{}
 func (c UserLayerCreator) Create(image Image, def DefinitionImage, _ SBOM) (Layer, error) {
 	files := make(map[*tar.Header]io.Reader)
 
-	img, err := image.ToDaemonImage()
-	if err != nil {
-		return Layer{}, err
-	}
+	img := image.Actual
 
 	tarBuffer, err := os.CreateTemp("", "")
 	if err != nil {

--- a/internal/image_test.go
+++ b/internal/image_test.go
@@ -416,7 +416,6 @@ func testImage(t *testing.T, context spec.G, it spec.S) {
 			context("image cannot be created from ref", func() {
 				it("returns an error", func() {
 					_, err := internal.GetBuildpackageID("index.docker.io/does-not-exist/go:0.5.0")
-					fmt.Println(err)
 					Expect(err).To(MatchError(ContainSubstring("UNAUTHORIZED: authentication required")))
 				})
 			})

--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -50,7 +50,7 @@ function unit::run() {
 
   testout=$(mktemp)
   pushd "${BUILDPACKDIR}" > /dev/null
-    if go test ./... -v -run "Unit|Example" | tee "${testout}"; then
+    if go test ./... -v -count=1 -run "Unit|Example" | tee "${testout}"; then
       util::tools::tests::checkfocus "${testout}"
       util::print::success "** GO Test Succeeded **"
     else


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The ihop.Client.Build method will now export the image from the Docker daemon as soon as the build completes, writing it to disk in OCI layout format. From this point on, the create-stack codebase will interact exclusively with the OCI layout image format. The advantage here is that we won't be shuttling an image back and forth between the Docker daemon and program memory or disk for every operation we need to perform. Instead, we can just manipulate the image on the local filesystem directly using the GGCR layout package.

## Use Cases
<!-- An explanation of the use cases your change enables -->
For large stacks like the Paketo Full stack, I was able to see a 10% improvement in build times on my local workstation. The vast majority of total time is taken up by the initial Docker build step which can't really be optimized externally. However, the remaining steps that add image labels and layers can. This change impacts those later pieces. For an image as large as the Full stack, we can still see significant improvements (on the order of minutes) from using an OCI layout as the concrete image format that we manipulate.

I haven't tested this in a GitHub runner, and would be interested to see how it fares in that environment, esp. for the Full stack.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
