### PR TITLE
Include stacks in dependencies section of summarize output

### DIFF
--- a/integration/summarize_test.go
+++ b/integration/summarize_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
 func testSummarize(t *testing.T, context spec.G, it spec.S) {
@@ -244,80 +245,81 @@ version = "3.4.5"
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(0), func() string { return buffer.String() })
 
-			Expect(string(session.Out.Contents())).To(Equal(`## Meta Buildpack 3.4.5` +
-
-				"\n\n**ID:** `meta-buildpack`\n\n" +
-
-				"**Digest:** `sha256:manifest-sha`" +
-				`
-
-#### Included Buildpackages:
-| Name | ID | Version |
-|---|---|---|
-| Some Buildpack | some-buildpack | 1.2.3 |
-| Other Buildpack | other-buildpack | 2.3.4 |
-
-<details>
-<summary>Order Groupings</summary>
-
-| ID | Version | Optional |
-|---|---|---|
-| some-buildpack | 1.2.3 | false |
-| other-buildpack | 2.3.4 | false |
-
-</details>
-
----
-
-<details>
-<summary>Some Buildpack 1.2.3</summary>` +
-
-				"\n\n**ID:** `some-buildpack`\n\n" +
-
-				"#### Supported Stacks:\n" +
-				"- `other-stack`\n" +
-				"- `some-stack`\n" +
-				`
-#### Default Dependency Versions:
-| ID | Version |
-|---|---|
-| other-dependency | 2.3.x |
-| some-dependency | 1.2.x |
-
-#### Dependencies:
-| Name | Version | Checksum |
-|---|---|---|
-| other-dependency | 2.3.4 | sha256:other-sha |
-| some-dependency | 1.2.3 | sha256:some-sha |
-
----
-
-</details>
-
-<details>
-<summary>Other Buildpack 2.3.4</summary>` +
-
-				"\n\n**ID:** `other-buildpack`\n\n" +
-				"#### Supported Stacks:\n" +
-				"- `first-stack`\n" +
-				"- `second-stack`\n" +
-				`
-#### Default Dependency Versions:
-| ID | Version |
-|---|---|
-| first-dependency | 4.5.x |
-| second-dependency | 5.6.x |
-
-#### Dependencies:
-| Name | Version | Checksum |
-|---|---|---|
-| first-dependency | 4.5.6 | sha256:first-sha |
-| second-dependency | 5.6.7 | sha256:second-sha |
-
----
-
-</details>
-`))
+			Expect(string(session.Out.Contents())).To(ContainLines(
+				"## Meta Buildpack 3.4.5",
+				"",
+				"**ID:** `meta-buildpack`",
+				"",
+				"**Digest:** `sha256:manifest-sha`",
+				"",
+				"#### Included Buildpackages:",
+				"| Name | ID | Version |",
+				"|---|---|---|",
+				"| Some Buildpack | some-buildpack | 1.2.3 |",
+				"| Other Buildpack | other-buildpack | 2.3.4 |",
+				"",
+				"<details>",
+				"<summary>Order Groupings</summary>",
+				"",
+				"| ID | Version | Optional |",
+				"|---|---|---|",
+				"| some-buildpack | 1.2.3 | false |",
+				"| other-buildpack | 2.3.4 | false |",
+				"",
+				"</details>",
+				"",
+				"---",
+				"",
+				"<details>",
+				"<summary>Some Buildpack 1.2.3</summary>",
+				"",
+				"**ID:** `some-buildpack`",
+				"",
+				"#### Supported Stacks:",
+				"- `other-stack`",
+				"- `some-stack`",
+				"",
+				"#### Default Dependency Versions:",
+				"| ID | Version |",
+				"|---|---|",
+				"| other-dependency | 2.3.x |",
+				"| some-dependency | 1.2.x |",
+				"",
+				"#### Dependencies:",
+				"| Name | Version | Stacks | Checksum |",
+				"|---|---|---|---|",
+				"| other-dependency | 2.3.4 | other-stack | sha256:other-sha |",
+				"| some-dependency | 1.2.3 | some-stack | sha256:some-sha |",
+				"",
+				"---",
+				"",
+				"</details>",
+				"",
+				"<details>",
+				"<summary>Other Buildpack 2.3.4</summary>",
+				"",
+				"**ID:** `other-buildpack`",
+				"",
+				"#### Supported Stacks:",
+				"- `first-stack`",
+				"- `second-stack`",
+				"",
+				"#### Default Dependency Versions:",
+				"| ID | Version |",
+				"|---|---|",
+				"| first-dependency | 4.5.x |",
+				"| second-dependency | 5.6.x |",
+				"",
+				"#### Dependencies:",
+				"| Name | Version | Stacks | Checksum |",
+				"|---|---|---|---|",
+				"| first-dependency | 4.5.6 | first-stack | sha256:first-sha |",
+				"| second-dependency | 5.6.7 | second-stack | sha256:second-sha |",
+				"",
+				"---",
+				"",
+				"</details>",
+			))
 		})
 	})
 

--- a/internal/formatter_test.go
+++ b/internal/formatter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
 func testFormatter(t *testing.T, context spec.G, it spec.S) {
@@ -48,7 +49,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 									ID:      "some-dependency",
 									Stacks:  []string{"other-stack"},
 									Version: "1.2.3",
-									SHA256:  "one-more-sha",
+									SHA256:  "other-sha",
 								},
 								{
 									ID:      "other-dependency",
@@ -76,29 +77,31 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 					SHA256: "sha256:some-buildpack-sha",
 				},
 			})
-			Expect(buffer.String()).To(Equal(`## Some Buildpack some-version` +
-
-				"\n\n**ID:** `some-buildpack`\n\n" +
-
-				"**Digest:** `sha256:some-buildpack-sha`\n\n" +
-				"#### Supported Stacks:\n" +
-				"- `other-stack`\n" +
-				"- `some-stack`\n" +
-				`
-#### Default Dependency Versions:
-| ID | Version |
-|---|---|
-| other-dependency | 2.3.x |
-| some-dependency | 1.2.x |
-
-#### Dependencies:
-| Name | Version | Checksum |
-|---|---|---|
-| other-dependency | 2.3.5 | sha512:some-sha |
-| other-dependency | 2.3.4 | sha256:another-sha |
-| some-dependency | 1.2.3 | sha256:one-more-sha |
-
-`))
+			Expect(buffer).To(ContainLines(
+				"## Some Buildpack some-version",
+				"",
+				"**ID:** `some-buildpack`",
+				"",
+				"**Digest:** `sha256:some-buildpack-sha`",
+				"",
+				"#### Supported Stacks:",
+				"- `other-stack`",
+				"- `some-stack`",
+				"",
+				"#### Default Dependency Versions:",
+				"| ID | Version |",
+				"|---|---|",
+				"| other-dependency | 2.3.x |",
+				"| some-dependency | 1.2.x |",
+				"",
+				"#### Dependencies:",
+				"| Name | Version | Stacks | Checksum |",
+				"|---|---|---|---|",
+				"| other-dependency | 2.3.5 | other-stack | sha512:some-sha |",
+				"| other-dependency | 2.3.4 | other-stack some-stack | sha256:another-sha |",
+				"| some-dependency | 1.2.3 | other-stack | sha256:other-sha |",
+				"| some-dependency | 1.2.3 | some-stack | sha256:one-more-sha |",
+			))
 		})
 
 		context("when dependencies and default-versions are empty", func() {
@@ -154,7 +157,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 										ID:      "some-dependency",
 										Stacks:  []string{"other-stack"},
 										Version: "1.2.3",
-										SHA256:  "one-more-sha",
+										SHA256:  "other-sha",
 									},
 									{
 										ID:      "other-dependency",
@@ -178,28 +181,27 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 						SHA256: "sha256:some-buildpack-sha",
 					},
 				})
-				Expect(buffer.String()).To(Equal(`## Some Buildpack some-version` +
-
-					"\n\n**ID:** `some-buildpack`\n\n" +
-
-					"**Digest:** `sha256:some-buildpack-sha`" +
-
-					`
-
-#### Default Dependency Versions:
-| ID | Version |
-|---|---|
-| other-dependency | 2.3.x |
-| some-dependency | 1.2.x |
-
-#### Dependencies:
-| Name | Version | Checksum |
-|---|---|---|
-| other-dependency | 2.3.5 | sha512:some-sha |
-| other-dependency | 2.3.4 | sha256:another-sha |
-| some-dependency | 1.2.3 | sha256:one-more-sha |
-
-`))
+				Expect(buffer).To(ContainLines(
+					"## Some Buildpack some-version",
+					"",
+					"**ID:** `some-buildpack`",
+					"",
+					"**Digest:** `sha256:some-buildpack-sha`",
+					"",
+					"#### Default Dependency Versions:",
+					"| ID | Version |",
+					"|---|---|",
+					"| other-dependency | 2.3.x |",
+					"| some-dependency | 1.2.x |",
+					"",
+					"#### Dependencies:",
+					"| Name | Version | Stacks | Checksum |",
+					"|---|---|---|---|",
+					"| other-dependency | 2.3.5 | other-stack | sha512:some-sha |",
+					"| other-dependency | 2.3.4 | other-stack some-stack | sha256:another-sha |",
+					"| some-dependency | 1.2.3 | other-stack | sha256:other-sha |",
+					"| some-dependency | 1.2.3 | some-stack | sha256:one-more-sha |",
+				))
 			})
 		})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The current `jam summarize` output does not show the stacks that a dependency applies to. For example, the recent MRI Buildpack v0.10.4 release shows the following dependencies table:

#### Dependencies:
| Name | Version | Checksum |
|---|---|---|
| ruby | 3.1.3 | sha256:04ebd8ebc799ad9cb877fc5ea5deced163b481bb113614cf59ec9a5b602cb055 |
| ruby | 3.1.3 | sha256:a9c084d0785d047f9b2394cccfb16acd326654c74f201abd6d220eef386addca |
| ruby | 3.1.2 | sha256:2df36ef8f98a8e45b5dae3a2c8c4b55298f35c3de707d4e9a46a1e7ebf285877 |
| ruby | 3.1.2 | sha256:8ec033a97e7c6074ce188eee74b465fe16e5870f06445e6fd1b001f5b8c567af |
| ruby | 3.0.5 | sha256:0de6dcaca9e8dd1efdcf07e400eab8a7a8f19b5b5bdf206cd8da16b59f93752c |
| ruby | 3.0.4 | sha256:9198d20052e1f95e387736b8c5e036c451796851f4284671ecfef30a00ad187a |
| ruby | 2.7.7 | sha256:1e003b9b9753d81a076a8034bc70efbed6be6c2d25e5c62c9f50bacf5c166f25 |
| ruby | 2.7.6 | sha256:20cb73d706b00d6b3fb2bdd0ccf3bce956d8f17c1886209b2ede56a6859bd8fc |

This output doesn't provide any disambiguation between versions of the ruby dependency that share the same version number, but differ in their stack association.

This PR adds "Stacks" as a column in this table which results in output that looks like the following:

#### Dependencies:
| Name | Version | Stacks | Checksum |
|---|---|---|---|
| ruby | 3.1.3 | io.buildpacks.stacks.bionic | sha256:04ebd8ebc799ad9cb877fc5ea5deced163b481bb113614cf59ec9a5b602cb055 |
| ruby | 3.1.3 | io.buildpacks.stacks.jammy | sha256:a9c084d0785d047f9b2394cccfb16acd326654c74f201abd6d220eef386addca |
| ruby | 3.1.2 | io.buildpacks.stacks.bionic | sha256:8ec033a97e7c6074ce188eee74b465fe16e5870f06445e6fd1b001f5b8c567af |
| ruby | 3.1.2 | io.buildpacks.stacks.jammy | sha256:2df36ef8f98a8e45b5dae3a2c8c4b55298f35c3de707d4e9a46a1e7ebf285877 |
| ruby | 3.0.5 | io.buildpacks.stacks.bionic | sha256:0de6dcaca9e8dd1efdcf07e400eab8a7a8f19b5b5bdf206cd8da16b59f93752c |
| ruby | 3.0.4 | io.buildpacks.stacks.bionic | sha256:9198d20052e1f95e387736b8c5e036c451796851f4284671ecfef30a00ad187a |
| ruby | 2.7.7 | io.buildpacks.stacks.bionic | sha256:1e003b9b9753d81a076a8034bc70efbed6be6c2d25e5c62c9f50bacf5c166f25 |
| ruby | 2.7.6 | io.buildpacks.stacks.bionic | sha256:20cb73d706b00d6b3fb2bdd0ccf3bce956d8f17c1886209b2ede56a6859bd8fc |

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
