### PR TITLE
Add support for platform specific arguments

### DIFF
--- a/integration/create_stack_test.go
+++ b/integration/create_stack_test.go
@@ -87,6 +87,17 @@ func testCreateStack(t *testing.T, _ spec.G, it spec.S) {
 				Architecture: "arm64",
 			}))
 
+			imageArm, err := index.Image(indexManifest.Manifests[1].Digest)
+			Expect(err).NotTo(HaveOccurred())
+
+			fileArm, err := imageArm.ConfigFile()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fileArm.Config.Labels).To(SatisfyAll(
+				// just check that the platform is different
+				HaveKeyWithValue("platform", "arm64"),
+			))
+
 			image, err := index.Image(indexManifest.Manifests[0].Digest)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -104,6 +115,7 @@ func testCreateStack(t *testing.T, _ spec.G, it spec.S) {
 				HaveKeyWithValue("io.buildpacks.stack.mixins", ContainSubstring(`"openssl"`)),
 				HaveKeyWithValue("io.buildpacks.stack.mixins", ContainSubstring(`"build:git"`)),
 				HaveKeyWithValue("io.paketo.stack.packages", ContainSubstring(`"openssl"`)),
+				HaveKeyWithValue("platform", "amd64"),
 			))
 
 			Expect(file.Config.Labels).NotTo(HaveKeyWithValue("io.buildpacks.stack.mixins", ContainSubstring("run:")))

--- a/integration/testdata/example-stack/build.Dockerfile
+++ b/integration/testdata/example-stack/build.Dockerfile
@@ -3,6 +3,9 @@
 FROM alpine:3.15.4
 
 ARG packages
+ARG platform
+
+LABEL platform=${platform}
 
 RUN apk add --no-cache ${packages}
 

--- a/integration/testdata/example-stack/run.Dockerfile
+++ b/integration/testdata/example-stack/run.Dockerfile
@@ -1,3 +1,5 @@
 FROM alpine:3.15.4
 ARG packages
+ARG platform
+LABEL platform=${platform}
 RUN apk add --no-cache ${packages}

--- a/integration/testdata/example-stack/stack.toml
+++ b/integration/testdata/example-stack/stack.toml
@@ -16,6 +16,12 @@ platforms = ["linux/amd64", "linux/arm64"]
   [build.args]
     packages = "curl git jq openssl"
 
+	[build.platforms."linux/amd64".args]
+	    platform = "amd64"
+
+	[build.platforms."linux/arm64".args]
+	    platform = "arm64"
+
 [run]
   description = "this run stack is for example purposes only"
   dockerfile = "./run.Dockerfile"
@@ -25,6 +31,12 @@ platforms = ["linux/amd64", "linux/arm64"]
 
   [run.args]
     packages = "openssl"
+
+	[run.platforms."linux/amd64".args]
+	    platform = "amd64"
+
+	[run.platforms."linux/arm64".args]
+	    platform = "arm64"
 
 [deprecated]
   legacy-sbom = true

--- a/internal/ihop/client.go
+++ b/internal/ihop/client.go
@@ -218,7 +218,7 @@ func (c Client) Build(def DefinitionImage, platform string) (Image, error) {
 	}
 	tag = fmt.Sprintf("paketo.io/stack/%s", tag)
 
-	buildArgs, err := def.Arguments()
+	buildArgs, err := def.Arguments(platform)
 	if err != nil {
 		return Image{}, err
 	}

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -50,6 +50,10 @@ type Definition struct {
 	IncludeExperimentalSBOM bool `toml:"-"`
 }
 
+type DefinitionImagePlatforms struct {
+	Args map[string]any `toml:"args"`
+}
+
 // DefinitionImage defines the definition of a build or run stack image.
 type DefinitionImage struct {
 	// Args can be used to pass arguments to the Dockerfile as might be done with
@@ -58,7 +62,7 @@ type DefinitionImage struct {
 
 	// Platforms is a map of additional platform specific arguments where the key
 	// is the platform name. Platform args of the same name override Args.
-	Platforms map[string]map[string]any `toml:"platforms"`
+	Platforms map[string]DefinitionImagePlatforms `toml:"platforms"`
 
 	// Description will be used to fill the io.buildpacks.stack.description image
 	// label.
@@ -137,8 +141,8 @@ func (d DefinitionImage) mergeArgs(platform string) map[string]any {
 		allArgs[key] = value
 	}
 
-	if platformArgs, ok := d.Platforms[platform]; ok {
-		for key, value := range platformArgs {
+	if platform, ok := d.Platforms[platform]; ok {
+		for key, value := range platform.Args {
 			allArgs[key] = value
 		}
 	}

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -44,7 +44,7 @@ platforms = ["some-stack-platform"]
 	[build.args]
 		some-build-arg-key = "some-build-arg-value"
 
-	[build.platforms."linux/arm64"]
+	[build.platforms."linux/arm64".args]
 	    some-build-platform-arg-key = "some-build-platform-arg-value"
 
 [run]
@@ -58,7 +58,7 @@ platforms = ["some-stack-platform"]
 	[run.args]
 		some-run-arg-key = "some-run-arg-value"
 
-	[run.platforms."linux/arm64"]
+	[run.platforms."linux/arm64".args]
 	    some-run-platform-arg-key = "some-run-platform-arg-value"
 
 [deprecated]
@@ -91,9 +91,11 @@ platforms = ["some-stack-platform"]
 					Args: map[string]any{
 						"some-build-arg-key": "some-build-arg-value",
 					},
-					Platforms: map[string]map[string]any{
+					Platforms: map[string]ihop.DefinitionImagePlatforms{
 						"linux/arm64": {
-							"some-build-platform-arg-key": "some-build-platform-arg-value",
+							Args: map[string]any{
+								"some-build-platform-arg-key": "some-build-platform-arg-value",
+							},
 						},
 					},
 					Description: "some-build-description",
@@ -106,9 +108,11 @@ platforms = ["some-stack-platform"]
 					Args: map[string]any{
 						"some-run-arg-key": "some-run-arg-value",
 					},
-					Platforms: map[string]map[string]any{
+					Platforms: map[string]ihop.DefinitionImagePlatforms{
 						"linux/arm64": {
-							"some-run-platform-arg-key": "some-run-platform-arg-value",
+							Args: map[string]any{
+								"some-run-platform-arg-key": "some-run-platform-arg-value",
+							},
 						},
 					},
 					Description: "some-run-description",
@@ -422,7 +426,7 @@ homepage = "https://github.com/some-stack"
 			3
 		]
 
-	[build.platforms."linux/arm64"]
+	[build.platforms."linux/arm64".args]
 	    build-arg-slice = [
 			"valueA",
 			"valueB",
@@ -437,7 +441,7 @@ homepage = "https://github.com/some-stack"
 	[run.args]
 		run-arg-int = 1
 
-	[run.platforms."linux/arm64"]
+	[run.platforms."linux/arm64".args]
 	    run-arg-int = 2
 `), 0600)
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

This PR adds support for platform-specific arguments in the `stack.toml` file for use when creating multi-architecture stacks.

The Build and Run settings can contain arguments, i.e. `[build.args]`. The same set of arguments is applied across all of the platforms. However, in some cases, it is necessary to have platform-specific arguments. To do this you can define `[build.platforms.<platform>]` and supply a list of arguments. The platform-specific arguments are overlaid on the general arguments, so you can override general args with platform-specific ones or add more arguments.

## Use Cases

When building Ubuntu mult-arch images, sources are different for amd64 and arm64. The stacks define a set of sources as arguments.

```
  [build.args]
    sources = """
    deb http://archive.ubuntu.com/ubuntu jammy main universe multiverse
    deb http://archive.ubuntu.com/ubuntu jammy-updates main universe multiverse
    deb http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse
    """
```

These need to be different depending on the architecture. This PR allows you to define an override per-platform.

```
  [build.platforms."linux/arm64"]
    sources = """
    deb http://ports.ubuntu.com/ubuntu-ports/ jammy main universe multiverse
    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main universe multiverse
    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe multiverse
    """
```

When that particular platform builds, jam will provide the platform-specific arguments so that the correct sources are used for that architecture.

## Outstanding Questions

- The structure that is currently being used in the TOML file won't be totally flexible. It assumes that the only platform-specific data will be arguments, i.e. `[build.platforms."linux/arm64"]` is a map of arguments. It does this to make the config file format a little easier and because we only need platform-specific args, but if we foresee the need to have other platform-specific data, then I can update the PR so that `[build.platforms."linux/arm64".args]` would be the key. Just let me know.
- The method `func (i DefinitionImage) Arguments() ([]string, error)` is changed in this PR to `func (i DefinitionImage) Arguments(platform string) ([]string, error)`. That is changing the function signature. I think that should be OK because it's in an internal package. Just wanted to call that out. If needed, I can make a second function that takes the platform and retain the existing method. Again, just let me know if that is preferred.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
