### PR TITLE
Upgrade module version to v2

### DIFF
--- a/commands/create_stack.go
+++ b/commands/create_stack.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 	"github.com/spf13/cobra"
 )

--- a/commands/pack.go
+++ b/commands/pack.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/paketo-buildpacks/packit/v2/pexec"
 	"github.com/paketo-buildpacks/packit/v2/scribe"

--- a/commands/summarize.go
+++ b/commands/summarize.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/update_builder.go
+++ b/commands/update_builder.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/update_buildpack.go
+++ b/commands/update_buildpack.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/update_dependencies.go
+++ b/commands/update_dependencies.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/paketo-buildpacks/jam
+module github.com/paketo-buildpacks/jam/v2
 
 go 1.18
 

--- a/integration/create_stack_test.go
+++ b/integration/create_stack_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
-	. "github.com/paketo-buildpacks/jam/integration/matchers"
+	. "github.com/paketo-buildpacks/jam/v2/integration/matchers"
 	. "github.com/paketo-buildpacks/packit/v2/matchers"
 )
 

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -40,7 +40,7 @@ func TestJam(t *testing.T) {
 		err    error
 	)
 
-	path, err = gexec.Build("github.com/paketo-buildpacks/jam", "-ldflags", `-X github.com/paketo-buildpacks/jam/commands.jamVersion=1.2.3`)
+	path, err = gexec.Build("github.com/paketo-buildpacks/jam/v2", "-ldflags", `-X github.com/paketo-buildpacks/jam/v2/commands.jamVersion=1.2.3`)
 	Expect(err).NotTo(HaveOccurred())
 
 	suite.Run(t)

--- a/integration/matchers/have_directory_test.go
+++ b/integration/matchers/have_directory_test.go
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/onsi/gomega/types"
-	"github.com/paketo-buildpacks/jam/integration/matchers"
+	"github.com/paketo-buildpacks/jam/v2/integration/matchers"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/integration/matchers/have_file_test.go
+++ b/integration/matchers/have_file_test.go
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/onsi/gomega/types"
-	"github.com/paketo-buildpacks/jam/integration/matchers"
+	"github.com/paketo-buildpacks/jam/v2/integration/matchers"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/integration/matchers/have_file_with_content_test.go
+++ b/integration/matchers/have_file_with_content_test.go
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/onsi/gomega/types"
-	"github.com/paketo-buildpacks/jam/integration/matchers"
+	"github.com/paketo-buildpacks/jam/v2/integration/matchers"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/integration/matchers/match_toml_content_test.go
+++ b/integration/matchers/match_toml_content_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega/types"
-	"github.com/paketo-buildpacks/jam/integration/matchers"
+	"github.com/paketo-buildpacks/jam/v2/integration/matchers"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/integration/update_dependencies_from_metadata_test.go
+++ b/integration/update_dependencies_from_metadata_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
-	. "github.com/paketo-buildpacks/jam/integration/matchers"
+	. "github.com/paketo-buildpacks/jam/v2/integration/matchers"
 	"github.com/paketo-buildpacks/occam"
 )
 

--- a/internal/builder_config_test.go
+++ b/internal/builder_config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/buildpack_config_test.go
+++ b/internal/buildpack_config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/buildpack_inspector_test.go
+++ b/internal/buildpack_inspector_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/sclevine/spec"
 

--- a/internal/dependency_cacher_test.go
+++ b/internal/dependency_cacher_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
-	"github.com/paketo-buildpacks/jam/internal/fakes"
+	"github.com/paketo-buildpacks/jam/v2/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal/fakes"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 	"github.com/sclevine/spec"

--- a/internal/dependency_test.go
+++ b/internal/dependency_test.go
@@ -3,7 +3,7 @@ package internal_test
 import (
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/sclevine/spec"
 

--- a/internal/file_bundler_test.go
+++ b/internal/file_bundler_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/sclevine/spec"
 

--- a/internal/formatter_test.go
+++ b/internal/formatter_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/sclevine/spec"
 

--- a/internal/ihop/builder_test.go
+++ b/internal/ihop/builder_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/sbom"
-	"github.com/paketo-buildpacks/jam/internal/ihop"
-	"github.com/paketo-buildpacks/jam/internal/ihop/fakes"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop/fakes"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/ihop/cataloger_test.go
+++ b/internal/ihop/cataloger_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/ihop/client_test.go
+++ b/internal/ihop/client_test.go
@@ -9,12 +9,12 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/paketo-buildpacks/packit/v2/vacation"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
-	. "github.com/paketo-buildpacks/jam/integration/matchers"
+	. "github.com/paketo-buildpacks/jam/v2/integration/matchers"
 )
 
 func testClient(t *testing.T, context spec.G, it spec.S) {

--- a/internal/ihop/creator_test.go
+++ b/internal/ihop/creator_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
-	"github.com/paketo-buildpacks/jam/internal/ihop"
-	"github.com/paketo-buildpacks/jam/internal/ihop/fakes"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop/fakes"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 	"github.com/sclevine/spec"
 

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/ihop/fakes/image_build_promise.go
+++ b/internal/ihop/fakes/image_build_promise.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 )
 
 type ImageBuildPromise struct {

--- a/internal/ihop/fakes/image_builder.go
+++ b/internal/ihop/fakes/image_builder.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 )
 
 type ImageBuilder struct {

--- a/internal/ihop/fakes/image_client.go
+++ b/internal/ihop/fakes/image_client.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 )
 
 type ImageClient struct {

--- a/internal/ihop/fakes/image_scanner.go
+++ b/internal/ihop/fakes/image_scanner.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 )
 
 type ImageScanner struct {

--- a/internal/ihop/fakes/layer_creator.go
+++ b/internal/ihop/fakes/layer_creator.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 )
 
 type LayerCreator struct {

--- a/internal/ihop/os_release_layer_creator_test.go
+++ b/internal/ihop/os_release_layer_creator_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/ihop/packages_test.go
+++ b/internal/ihop/packages_test.go
@@ -3,7 +3,7 @@ package ihop_test
 import (
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/ihop/sbom_layer_creator_test.go
+++ b/internal/ihop/sbom_layer_creator_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/ihop/sbom_test.go
+++ b/internal/ihop/sbom_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/ihop/user_layer_creator_test.go
+++ b/internal/ihop/user_layer_creator_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal/ihop"
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/image_test.go
+++ b/internal/image_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/package_config_test.go
+++ b/internal/package_config_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"

--- a/internal/pre_packager_test.go
+++ b/internal/pre_packager_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/paketo-buildpacks/jam/internal"
-	"github.com/paketo-buildpacks/jam/internal/fakes"
+	"github.com/paketo-buildpacks/jam/v2/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal/fakes"
 	"github.com/paketo-buildpacks/packit/v2/pexec"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 	"github.com/sclevine/spec"

--- a/internal/tar_builder_test.go
+++ b/internal/tar_builder_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/paketo-buildpacks/jam/internal"
+	"github.com/paketo-buildpacks/jam/v2/internal"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 	"github.com/sclevine/spec"
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/paketo-buildpacks/jam/commands"
+	"github.com/paketo-buildpacks/jam/v2/commands"
 )
 
 func main() {

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -75,7 +75,7 @@ function build::jam(){
       GOARCH="amd64" \
       CGO_ENABLED=0 \
         go build \
-          -ldflags "-X github.com/paketo-buildpacks/jam/commands.jamVersion=${version}" \
+          -ldflags "-X github.com/paketo-buildpacks/jam/v2/commands.jamVersion=${version}" \
           -o "${output}" \
           main.go
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

According to https://go.dev/blog/v2-go-modules:

> Starting with v2, the major version must appear at the end of the module path (declared in the module statement in the go.mod file). For example, when the authors of the module github.com/googleapis/gax-go developed v2, they used the new module path github.com/googleapis/gax-go/v2. Users who wanted to use v2 had to change their package imports and module requirements to github.com/googleapis/gax-go/v2.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Currently it's impossible to import the latest `jam` version as a dependency:

```console
$ go mod tidy
go: errors parsing go.mod:
go.mod:10:2: require github.com/paketo-buildpacks/jam: version "v2.0.0" invalid: should be v0 or v1, not v2
```


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
