### PR TITLE
Build/publish `arm64` binaries during release

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -86,13 +86,43 @@ jobs:
               "content_type": "application/octet-stream"
             },
             {
+              "path": "build/jam-darwin",
+              "name": "jam-darwin-amd64",
+              "content_type": "application/octet-stream"
+            },
+            {
+              "path": "build/jam-darwin-arm64",
+              "name": "jam-darwin-arm64",
+              "content_type": "application/octet-stream"
+            },
+            {
               "path": "build/jam-linux",
               "name": "jam-linux",
               "content_type": "application/octet-stream"
             },
             {
+              "path": "build/jam-linux",
+              "name": "jam-linux-amd64",
+              "content_type": "application/octet-stream"
+            },
+            {
+              "path": "build/jam-linux-arm64",
+              "name": "jam-linux-arm64",
+              "content_type": "application/octet-stream"
+            },
+            {
               "path": "build/jam-windows.exe",
               "name": "jam-windows.exe",
+              "content_type": "application/octet-stream"
+            },
+            {
+              "path": "build/jam-windows.exe",
+              "name": "jam-windows-amd64.exe",
+              "content_type": "application/octet-stream"
+            },
+            {
+              "path": "build/jam-windows-arm64.exe",
+              "name": "jam-windows-arm64.exe",
               "content_type": "application/octet-stream"
             }
           ]

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -63,23 +63,28 @@ function build::jam(){
 
   pushd "${ROOT_DIR}" > /dev/null || return
     for os in darwin linux windows; do
-      util::print::info "Building jam on ${os}"
+      for arch in amd64 arm64; do
+        util::print::info "Building jam on ${os} for ${arch}"
 
-      local output
-      output="${ARTIFACTS_DIR}/jam-${os}"
-      if [[ "${os}"  == "windows" ]]; then
-        output="${output}.exe"
-      fi
+        local output
+        output="${ARTIFACTS_DIR}/jam-${os}"
+        if [[ "${arch}" != "amd64" ]]; then
+          output="${output}-${arch}"
+        fi
+        if [[ "${os}" == "windows" ]]; then
+          output="${output}.exe"
+        fi
 
-      GOOS="${os}" \
-      GOARCH="amd64" \
-      CGO_ENABLED=0 \
-        go build \
-          -ldflags "-X github.com/paketo-buildpacks/jam/v2/commands.jamVersion=${version}" \
-          -o "${output}" \
-          main.go
+        GOOS="${os}" \
+        GOARCH="${arch}" \
+        CGO_ENABLED=0 \
+          go build \
+            -ldflags "-X github.com/paketo-buildpacks/jam/v2/commands.jamVersion=${version}" \
+            -o "${output}" \
+            main.go
 
-      chmod +x "${output}"
+        chmod +x "${output}"
+      done
     done
   popd > /dev/null || return
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Builds and publishes `arm64` versions of artifacts during release process. Also, publishes the  `amd64` versions with original names (no architecture mentioned, for backwards compatibility) and names that include `amd64` (for easier integration in other tools). [addresses paketo-buildpacks/jam#240]

## Use Cases
`arm64` is an emerging architecture and `jam` artifacts should be available for that architecture as well.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
