### PR TITLE
Set /home/cnb file mode to 750

### DIFF
--- a/internal/ihop/user_layer_creator.go
+++ b/internal/ihop/user_layer_creator.go
@@ -87,7 +87,7 @@ func (c UserLayerCreator) Create(image Image, def DefinitionImage, _ SBOM) (Laye
 	err = tw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeDir,
 		Name:     "home/cnb",
-		Mode:     int64(os.ModePerm),
+		Mode:     int64(os.FileMode(0750)),
 		Uid:      def.UID,
 		Gid:      def.GID,
 	})


### PR DESCRIPTION
## Summary
Set /home/cnb file mode to 750

## Use Cases
750 complies with security recommendations such as those made by CIS.

See: https://www.unifiedcompliance.com/products/search-controls/control/01588/

Security scanners are flagging build pack created images due to these too permission file permissions.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
