### PR TITLE
Strip off preceding '.' from layer header names if present.

### DIFF
--- a/internal/ihop/image.go
+++ b/internal/ihop/image.go
@@ -42,7 +42,12 @@ func findFile(image v1.Image, filepath string) (*tar.Header, io.Reader, error) {
 				return nil, nil, err
 			}
 
-			if strings.TrimPrefix(hdr.Name, "/") == strings.TrimPrefix(filepath, "/") {
+			// Some images have filepaths with a preceding '.'
+			// e.g. './etc/...' instead of '/etc/...'
+			// Strip it off if it exists
+			headerName := strings.TrimPrefix(hdr.Name, ".")
+
+			if strings.TrimPrefix(headerName, "/") == strings.TrimPrefix(filepath, "/") {
 				found = true
 				if hdr.Typeflag == tar.TypeSymlink {
 					header, reader, err = findFile(image, path.Join(path.Dir(filepath), hdr.Linkname))


### PR DESCRIPTION
## Summary

This PR fixes a bug where `jam create-stack` would panic with a nil pointer on some images (e.g. VMware Photon OS). These images have file headers in the format `./etc/...` rather than `/etc/...` so we have to strip off the preceding `.`.

## Use Cases

Support more Operating Systems for stack creation.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
