### PR TITLE
support extensions in update_builder command

### DIFF
--- a/commands/update_builder.go
+++ b/commands/update_builder.go
@@ -67,6 +67,31 @@ func updateBuilderRun(flags updateBuilderFlags) error {
 		}
 	}
 
+	for i, extension := range builder.Extensions {
+		image, err := internal.FindLatestImage(extension.URI)
+		if err != nil {
+			return err
+		}
+
+		builder.Extensions[i].Version = image.Version
+		builder.Extensions[i].URI = fmt.Sprintf("%s:%s", image.Name, image.Version)
+
+		extensionID, err := internal.GetBuildpackageID(extension.URI)
+		if err != nil {
+			return fmt.Errorf("failed to get extension ID for %s: %w", extension.URI, err)
+		}
+
+		for j, orderextensions := range builder.OrderExtension {
+			for k, group := range orderextensions.Group {
+				if group.ID == extensionID {
+					if builder.OrderExtension[j].Group[k].Version != "" {
+						builder.OrderExtension[j].Group[k].Version = image.Version
+					}
+				}
+			}
+		}
+	}
+
 	lifecycleImage, err := internal.FindLatestImage(flags.lifecycleURI)
 	if err != nil {
 		return err

--- a/internal/builder_config_test.go
+++ b/internal/builder_config_test.go
@@ -35,6 +35,11 @@ description = "Some description"
 	image = "some-registry/some-repository/other-buildpack-id:0.20.22"
   version = "0.20.22"
 
+[[extensions]]
+  id = "some-repository/some-extension"
+  version = "0.0.3"
+  uri = "some-registry/some-repository/some-extension:0.0.3"
+
 [lifecycle]
   version = "0.10.2"
 
@@ -49,6 +54,12 @@ description = "Some description"
     id = "some-repository/some-buildpack-id"
     version = "0.0.10"
 		optional = true
+
+[[order-extensions]]
+
+  [[order-extensions.group]]
+    id = "some-repository/some-extension"
+    version = "0.0.3"
 
 [stack]
   id = "io.paketo.stacks.some-stack"
@@ -80,6 +91,13 @@ description = "Some description"
 						Version: "0.20.22",
 					},
 				},
+				Extensions: []internal.BuilderConfigExtension{
+					{
+						ID:      "some-repository/some-extension",
+						URI:     "some-registry/some-repository/some-extension:0.0.3",
+						Version: "0.0.3",
+					},
+				},
 				Lifecycle: internal.BuilderConfigLifecycle{
 					Version: "0.10.2",
 				},
@@ -97,6 +115,16 @@ description = "Some description"
 								ID:       "some-repository/some-buildpack-id",
 								Version:  "0.0.10",
 								Optional: true,
+							},
+						},
+					},
+				},
+				OrderExtension: []internal.BuilderExtensionConfigOrder{
+					{
+						Group: []internal.BuilderExtensionConfigOrderGroup{
+							{
+								ID:      "some-repository/some-extension",
+								Version: "0.0.3",
 							},
 						},
 					},
@@ -190,6 +218,113 @@ description = "Some description"
 						Version: "0.20.22",
 					},
 				},
+				Extensions: []internal.BuilderConfigExtension{
+					{
+						ID:      "some-repository/some-extension",
+						URI:     "some-registry/some-repository/some-extension:0.0.3",
+						Version: "0.0.3",
+					},
+				},
+				Lifecycle: internal.BuilderConfigLifecycle{
+					Version: "0.10.2",
+				},
+				Order: []internal.BuilderConfigOrder{
+					{
+						Group: []internal.BuilderConfigOrderGroup{
+							{
+								ID:      "some-repository/other-buildpack-id",
+								Version: "0.20.22",
+							},
+						},
+					},
+					{
+						Group: []internal.BuilderConfigOrderGroup{
+							{
+								ID:      "some-repository/some-buildpack-id",
+								Version: "0.0.10",
+							},
+						},
+					},
+				},
+				OrderExtension: []internal.BuilderExtensionConfigOrder{
+					{
+						Group: []internal.BuilderExtensionConfigOrderGroup{
+							{
+								ID:      "some-repository/some-extension",
+								Version: "0.0.3",
+							},
+						},
+					},
+				},
+				Stack: internal.BuilderConfigStack{
+					ID:              "io.paketo.stacks.some-stack",
+					BuildImage:      "some-registry/somerepository/build:1.2.3-some-cnb",
+					RunImage:        "some-registry/somerepository/run:some-cnb",
+					RunImageMirrors: []string{"some-registry/some-repository/run:some-cnb"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			contents, err := os.ReadFile(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(contents)).To(MatchTOML(`
+description = "Some description"
+
+[[buildpacks]]
+	uri = "docker://some-registry/some-repository/some-buildpack-id:0.0.10"
+  version = "0.0.10"
+
+[[buildpacks]]
+	uri = "docker://some-registry/some-repository/other-buildpack-id:0.20.22"
+  version = "0.20.22"
+
+[[extensions]]
+  id = "some-repository/some-extension"
+  version = "0.0.3"
+  uri = "docker://some-registry/some-repository/some-extension:0.0.3"
+
+[lifecycle]
+  version = "0.10.2"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/other-buildpack-id"
+    version = "0.20.22"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/some-buildpack-id"
+    version = "0.0.10"
+
+[[order-extensions]]
+
+  [[order-extensions.group]]
+    id = "some-repository/some-extension"
+    version = "0.0.3"
+
+[stack]
+  id = "io.paketo.stacks.some-stack"
+  build-image = "some-registry/somerepository/build:1.2.3-some-cnb"
+  run-image = "some-registry/somerepository/run:some-cnb"
+  run-image-mirrors = ["some-registry/some-repository/run:some-cnb"]
+				`))
+		})
+
+		it("overwrites the package.toml configuration without Extension", func() {
+			err := internal.OverwriteBuilderConfig(path, internal.BuilderConfig{
+				Description: "Some description",
+				Buildpacks: []internal.BuilderConfigBuildpack{
+					{
+						URI:     "some-registry/some-repository/some-buildpack-id:0.0.10",
+						Version: "0.0.10",
+					},
+					{
+						URI:     "some-registry/some-repository/other-buildpack-id:0.20.22",
+						Version: "0.20.22",
+					},
+				},
 				Lifecycle: internal.BuilderConfigLifecycle{
 					Version: "0.10.2",
 				},
@@ -254,8 +389,8 @@ description = "Some description"
   run-image = "some-registry/somerepository/run:some-cnb"
   run-image-mirrors = ["some-registry/some-repository/run:some-cnb"]
 				`))
-		})
 
+		})
 		context("failure cases", func() {
 			context("when the file cannot be opened", func() {
 				it.Before(func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Add handling of extension sections in builder toml files
Refs: https://github.com/paketo-buildpacks/jam/issues/294

## Use Cases
<!-- An explanation of the use cases your change enables -->
Supports update of toml files for builders that use extensions

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
