### PR TITLE
Update Buildpack: add `--patch-only` flag

### DIFF
--- a/commands/update_builder.go
+++ b/commands/update_builder.go
@@ -43,7 +43,7 @@ func updateBuilderRun(flags updateBuilderFlags) error {
 	}
 
 	for i, buildpack := range builder.Buildpacks {
-		image, err := internal.FindLatestImage(buildpack.URI)
+		image, err := internal.FindLatestImage(buildpack.URI, "")
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func updateBuilderRun(flags updateBuilderFlags) error {
 	}
 
 	for i, extension := range builder.Extensions {
-		image, err := internal.FindLatestImage(extension.URI)
+		image, err := internal.FindLatestImage(extension.URI, "")
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func updateBuilderRun(flags updateBuilderFlags) error {
 		}
 	}
 
-	lifecycleImage, err := internal.FindLatestImage(flags.lifecycleURI)
+	lifecycleImage, err := internal.FindLatestImage(flags.lifecycleURI, "")
 	if err != nil {
 		return err
 	}

--- a/commands/update_buildpack.go
+++ b/commands/update_buildpack.go
@@ -15,6 +15,7 @@ type updateBuildpackFlags struct {
 	api           string
 
 	noCNBRegistry bool
+	patchOnly     bool
 }
 
 func updateBuildpack() *cobra.Command {
@@ -30,6 +31,7 @@ func updateBuildpack() *cobra.Command {
 	cmd.Flags().StringVar(&flags.packageFile, "package-file", "", "path to the package.toml file (required)")
 	cmd.Flags().StringVar(&flags.api, "api", "https://registry.buildpacks.io/api/", "api for cnb registry (default: https://registry.buildpacks.io/api/)")
 	cmd.Flags().BoolVar(&flags.noCNBRegistry, "no-cnb-registry", false, "buildpacks not available on the CNB registry, so will revert to previous image references behavior")
+	cmd.Flags().BoolVar(&flags.patchOnly, "patch-only", false, "allow patch changes ONLY to buildpack version bumps")
 
 	err := cmd.MarkFlagRequired("buildpack-file")
 	if err != nil {
@@ -68,6 +70,19 @@ func updateBuildpackRun(flags updateBuildpackFlags) error {
 			if err != nil {
 				return err
 			}
+			// If the new version is NOT a patch, and --patch-only is set, don't update
+			if flags.patchOnly {
+				oldVersionSlice := strings.Split(dependency.URI, ":")
+				oldVersion := oldVersionSlice[len(oldVersionSlice)-1]
+				isPatchBump, err := internal.IsPatchBump(image.Version, oldVersion)
+				if err != nil {
+					return err
+				}
+				if !isPatchBump {
+					fmt.Printf("The latest version of %s is %s, which not a patch release. As a result, it will not be updated\n", image.Name, image.Version)
+					continue
+				}
+			}
 
 			pkg.Dependencies[i].URI = fmt.Sprintf("%s:%s", image.Name, image.Version)
 
@@ -87,6 +102,24 @@ func updateBuildpackRun(flags updateBuildpackFlags) error {
 			image, err = internal.FindLatestImageOnCNBRegistry(uri, flags.api)
 			if err != nil {
 				return err
+			}
+			// If the new version is NOT a patch, and --patch-only is set, don't update
+			if flags.patchOnly {
+				var oldVersion string
+				if strings.Contains(dependency.URI, "@") {
+					oldVersion = strings.Split(dependency.URI, "@")[1]
+				} else {
+					oldVersionSlice := strings.Split(dependency.URI, ":")
+					oldVersion = oldVersionSlice[len(oldVersionSlice)-1]
+				}
+				isPatchBump, err := internal.IsPatchBump(image.Version, oldVersion)
+				if err != nil {
+					return fmt.Errorf("Error determining if %s is a patch bump: %w", image.Name, err)
+				}
+				if !isPatchBump {
+					fmt.Printf("The latest version of %s is %s, which not a patch release. As a result, it will not be updated\n", image.Name, image.Version)
+					continue
+				}
 			}
 
 			pkg.Dependencies[i].URI = fmt.Sprintf("%s@%s", image.Name, image.Version)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/BurntSushi/toml v1.3.2
+	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/anchore/syft v0.80.0
 	github.com/buildpacks/pack v0.29.0

--- a/integration/update_buildpack_test.go
+++ b/integration/update_buildpack_test.go
@@ -64,8 +64,22 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 					w.WriteHeader(http.StatusOK)
 					fmt.Fprintln(w, `{
 						"latest": {
-							"version": "0.20.12"
-						}
+							"version": "0.21.0"
+						},
+					  "versions": [
+					    {
+					      "version": "0.20.1"
+					    },
+					    {
+					      "version": "0.20.2"
+					    },
+					    {
+					      "version": "0.20.12"
+					    },
+					    {
+					      "version": "0.21.0"
+					    }
+						]
 					}`)
 
 				case "/v1/buildpacks/paketo-buildpacks/mri":
@@ -73,7 +87,12 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 					fmt.Fprintln(w, `{
 						"latest": {
 							"version": "0.2.0"
-						}
+						},
+					  "versions": [
+					    {
+					      "version": "0.2.0"
+					    }
+						]
 					}`)
 
 				case "/v1/buildpacks/paketo-buildpacks/node-engine":
@@ -81,7 +100,12 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 					fmt.Fprintln(w, `{
 						"latest": {
 							"version": "0.20.22"
-						}
+						},
+					  "versions": [
+					    {
+					      "version": "0.20.22"
+					    }
+						]
 					}`)
 
 				case goConfigPath:
@@ -221,7 +245,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 				[[order]]
 					[[order.group]]
 						id = "paketo-buildpacks/go-dist"
-						version = "0.20.12"
+						version = "0.21.0"
 
 					[[order.group]]
 						id = "paketo-buildpacks/mri"
@@ -235,7 +259,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 
 					[[order.group]]
 						id = "paketo-buildpacks/go-dist"
-						version = "0.20.12"
+						version = "0.21.0"
 			`))
 
 			packageContents, err := os.ReadFile(filepath.Join(buildpackDir, "package.toml"))
@@ -248,7 +272,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 				uri = "urn:cnb:registry:paketo-buildpacks/mri@0.2.0"
 
 				[[dependencies]]
-				uri = "urn:cnb:registry:paketo-buildpacks/go-dist@0.20.12"
+				uri = "urn:cnb:registry:paketo-buildpacks/go-dist@0.21.0"
 
 				[[dependencies]]
 				uri = "urn:cnb:registry:paketo-buildpacks/node-engine@0.20.22"
@@ -628,6 +652,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 								"0.0.10",
 								"0.20.1",
 								"0.20.12",
+								"0.21.0",
 								"latest"
 							]
 					}`)
@@ -801,7 +826,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 				[[order]]
 					[[order.group]]
 						id = "paketo-buildpacks/go-dist"
-						version = "0.20.12"
+						version = "0.21.0"
 
 					[[order.group]]
 						id = "paketo-buildpacks/mri"
@@ -815,7 +840,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 
 					[[order.group]]
 						id = "paketo-buildpacks/go-dist"
-						version = "0.20.12"
+						version = "0.21.0"
 			`))
 
 			packageContents, err := os.ReadFile(filepath.Join(buildpackDir, "package.toml"))
@@ -828,7 +853,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 				uri = "docker://REGISTRY-URI/paketobuildpacks/mri:0.2.0"
 
 				[[dependencies]]
-				uri = "docker://REGISTRY-URI/paketo-buildpacks/go-dist:0.20.12"
+				uri = "docker://REGISTRY-URI/paketo-buildpacks/go-dist:0.21.0"
 
 				[[dependencies]]
 				uri = "docker://REGISTRY-URI/paketobuildpacks/node-engine:0.20.22"

--- a/internal/image.go
+++ b/internal/image.go
@@ -83,7 +83,7 @@ func FindLatestImageOnCNBRegistry(uri, api, patchVersion string) (Image, error) 
 			versions = append(versions, v.Version)
 		}
 
-		highestPatch, err := GetHighestPatch(patchVersion, versions)
+		highestPatch, err := getHighestPatch(patchVersion, versions)
 		if err != nil {
 			return Image{}, fmt.Errorf("could not get the highest patch in the %s line: %w", patchVersion, err)
 		}
@@ -123,7 +123,7 @@ func FindLatestImage(uri, patchVersion string) (Image, error) {
 	}
 
 	if patchVersion != "" {
-		highestPatch, err := GetHighestPatch(patchVersion, tags)
+		highestPatch, err := getHighestPatch(patchVersion, tags)
 		if err != nil {
 			return Image{}, fmt.Errorf("could not get the highest patch in the %s line: %w", patchVersion, err)
 		}
@@ -132,8 +132,8 @@ func FindLatestImage(uri, patchVersion string) (Image, error) {
 			Path:    reference.Path(named),
 			Version: highestPatch,
 		}, nil
-
 	}
+
 	var versions []*semver.Version
 	for _, tag := range tags {
 		version, err := semver.StrictNewVersion(tag)
@@ -258,7 +258,7 @@ func GetBuildpackageID(uri string) (string, error) {
 	return metadata.BuildpackageID, nil
 }
 
-func GetHighestPatch(patchVersion string, allVersions []string) (string, error) {
+func getHighestPatch(patchVersion string, allVersions []string) (string, error) {
 	versionConstraint, err := semver.NewConstraint(fmt.Sprintf("~%s", patchVersion))
 	if err != nil {
 		return "", fmt.Errorf("version constraint ~%s is not a valid semantic version constraint: %w", patchVersion, err)

--- a/internal/image.go
+++ b/internal/image.go
@@ -224,3 +224,16 @@ func GetBuildpackageID(uri string) (string, error) {
 	}
 	return metadata.BuildpackageID, nil
 }
+
+func IsPatchBump(newVersion, oldVersion string) (bool, error) {
+	newVersionSemver, err := semver.NewVersion(newVersion)
+	if err != nil {
+		return false, fmt.Errorf("version %s is not semantically versioned: %w", newVersion, err)
+	}
+	oldVersionConstraint, err := semver.NewConstraint(fmt.Sprintf("~%s", oldVersion))
+	if err != nil {
+		return false, fmt.Errorf("version constraint ~%s is not a valid semantic version constraint: %w", oldVersion, err)
+	}
+
+	return oldVersionConstraint.Check(newVersionSemver), nil
+}

--- a/internal/image_test.go
+++ b/internal/image_test.go
@@ -454,4 +454,38 @@ func testImage(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+
+	context("IsPatchBump", func() {
+		context("new version is a patch bump from old version", func() {
+			it("returns true", func() {
+				isPatch, err := internal.IsPatchBump("1.2.3", "1.2.1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isPatch).To(BeTrue())
+			})
+		})
+
+		context("new version is a minor bump from old version", func() {
+			it("returns false ", func() {
+				isPatch, err := internal.IsPatchBump("1.3.0", "1.2.1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isPatch).To(BeFalse())
+			})
+		})
+
+		context("failure cases", func() {
+			context("new version is not a semantic version", func() {
+				it("returns an error", func() {
+					_, err := internal.IsPatchBump("bad-version", "1.2.1")
+					Expect(err).To(MatchError(ContainSubstring("version bad-version is not semantically versioned")))
+				})
+			})
+
+			context("old version is not a semantic version", func() {
+				it("returns an error", func() {
+					_, err := internal.IsPatchBump("1.2.3", "bad-version")
+					Expect(err).To(MatchError(ContainSubstring("version constraint ~bad-version is not a valid semantic version constraint")))
+				})
+			})
+		})
+	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds new boolean flag `--patch-only` flag to `jam update-buildpack` command. When used, only buildpack version bumps that are in the same minor version line (patch version updates) will be considered and added to the buildpack.toml and package.toml updates.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Avoid inadvertently adding minor version bumps into a composite buildpack 

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
