### PR TITLE
Use stable version of go in create-release workflow

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 'stable'
     - name: Checkout
       uses: actions/checkout@v3
     - name: Setup Docker Multi-Platform Builds
@@ -40,7 +40,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 'stable'
     - name: Checkout
       uses: actions/checkout@v3
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true


### PR DESCRIPTION
## Summary / Use Cases

We are using an unsupported version of go, which is causing compilation errors (e.g. [this build](https://github.com/paketo-buildpacks/jam/actions/runs/6816726764/job/18538686415)). This PR switches to `stable`, which is what we use elsewhere and is guaranteed to be supported and up to date.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
