### PR TITLE
Amend `update-builder` functionality

### DIFF
--- a/commands/update_builder.go
+++ b/commands/update_builder.go
@@ -99,12 +99,20 @@ func updateBuilderRun(flags updateBuilderFlags) error {
 
 	builder.Lifecycle.Version = lifecycleImage.Version
 
-	buildImage, err := internal.FindLatestBuildImage(builder.Stack.RunImage, builder.Stack.BuildImage)
+	runImage, buildImage, err := internal.FindLatestStackImages(builder.Stack.RunImage, builder.Stack.BuildImage)
 	if err != nil {
 		return err
 	}
 
 	builder.Stack.BuildImage = fmt.Sprintf("%s:%s", buildImage.Name, buildImage.Version)
+	if runImage != (internal.Image{}) {
+		builder.Stack.RunImage = fmt.Sprintf("%s:%s", runImage.Name, runImage.Version)
+		updatedMirrors, err := internal.UpdateRunImageMirrors(runImage.Version, builder.Stack.RunImageMirrors)
+		if err != nil {
+			return err
+		}
+		builder.Stack.RunImageMirrors = updatedMirrors
+	}
 
 	err = internal.OverwriteBuilderConfig(flags.builderFile, builder)
 	if err != nil {

--- a/internal/image.go
+++ b/internal/image.go
@@ -234,7 +234,9 @@ func FindLatestBuildImage(runURI, buildURI string) (Image, error) {
 			continue
 		}
 
-		// legacy case: if the run image tag has a suffix (ex. 1.2.3-suffix) (ex. suffix), it should be eequal to the build image suffix
+		// legacy case: if the build image tag has a suffix (ex.
+		// <image>:1.2.3-suffix) (ex. <image>:suffix), it should be equal to the
+		// run image tag suffix in order to be considered as a valid version
 		// See this PR for more context: https://github.com/paketo-buildpacks/jam/pull/81
 		if version.Prerelease() != "" && runTagSuffix != version.Prerelease() {
 			fmt.Printf("Skipping build image version: %s, the tag suffix does not match run image tag: %s\n", tag, runTagSuffix)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Allows the `jam update-builder` command to update the run image (and associated run image mirrors) if the run image tag is semantically versioned instead of `latest`. There are some use cases (such as not being able to publish to `latest`) that make this use case helpful. Prior to this change, this use case caused errors when executing.

The PR makes the following choices:
- If the run image tag is a semantic version (`x.y.z` or `x.y.z-suffix`), **we should update it to match the latest build image version, to keep the stack images in lockstep.** This assumes the run/build images of a stack are versioned and released together. I think this is simpler than re-calculating the highest tag version available twice, once for build and once for run.


- If the builder.toml file has run image mirrors present, update them to the same version as the build/run image if the run image has been updated

- Continue to support the "legacy tagging convention" in which tags may have a suffix (like `-cnb`), although none of our officially supported Paketo stack images use this mechanism, see
https://github.com/paketo-buildpacks/jam/pull/81

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
