### PR TITLE
Adding extension flag to summarize an extension buildpackage

### DIFF
--- a/integration/summarize_test.go
+++ b/integration/summarize_test.go
@@ -433,7 +433,7 @@ version = "3.4.5"
 	})
 
 	context("failure cases", func() {
-		context("when the required buildpack flag is not set", func() {
+		context("when the required buildpack or extension flag is not set", func() {
 			it("prints an error message", func() {
 				command := exec.Command(
 					path, "summarize",
@@ -443,7 +443,7 @@ version = "3.4.5"
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(1), func() string { return buffer.String() })
 
-				Expect(session.Err.Contents()).To(ContainSubstring("Error: required flag(s) \"buildpack\" not set"))
+				Expect(session.Err.Contents()).To(ContainSubstring("Error: at least one of the flags in the group [buildpack extension] is required"))
 			})
 		})
 	})

--- a/internal/extension_formatter.go
+++ b/internal/extension_formatter.go
@@ -1,0 +1,115 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+)
+
+type ExtensionFormatter struct {
+	writer io.Writer
+}
+
+func NewExtensionFormatter(writer io.Writer) ExtensionFormatter {
+	return ExtensionFormatter{
+		writer: writer,
+	}
+}
+
+func printExtensionImplementation(writer io.Writer, config cargo.ExtensionConfig) {
+
+	if len(config.Metadata.DefaultVersions) > 0 {
+		fmt.Fprintf(writer, "#### Default Dependency Versions:\n| ID | Version |\n|---|---|\n")
+		var sortedDependencies []string
+		for key := range config.Metadata.DefaultVersions {
+			sortedDependencies = append(sortedDependencies, key)
+		}
+
+		sort.Strings(sortedDependencies)
+
+		for _, key := range sortedDependencies {
+			fmt.Fprintf(writer, "| %s | %s |\n", key, config.Metadata.DefaultVersions[key])
+		}
+		fmt.Fprintln(writer)
+	}
+
+	if len(config.Metadata.Dependencies) > 0 {
+		infoMap := map[depKey][]string{}
+		for _, d := range config.Metadata.Dependencies {
+
+			key := depKey{d.ID, d.Version, d.Source}
+			_, ok := infoMap[key]
+			if !ok {
+				sort.Strings(d.Stacks)
+				infoMap[key] = d.Stacks
+			} else {
+				val := infoMap[key]
+				val = append(val, d.Stacks...)
+				sort.Strings(val)
+				infoMap[key] = val
+			}
+		}
+
+		var sorted []cargo.ConfigExtensionMetadataDependency
+		for key, stacks := range infoMap {
+			sorted = append(sorted, cargo.ConfigExtensionMetadataDependency{
+				ID:      key[0],
+				Version: key[1],
+				Stacks:  stacks,
+				Source:  key[2],
+			})
+		}
+
+		sort.Slice(sorted, func(i, j int) bool {
+			iVal := sorted[i]
+			jVal := sorted[j]
+
+			if iVal.ID == jVal.ID {
+				iVersion := semver.MustParse(iVal.Version)
+				jVersion := semver.MustParse(jVal.Version)
+
+				if iVersion.Equal(jVersion) {
+					iStacks := strings.Join(iVal.Stacks, " ")
+					jStacks := strings.Join(jVal.Stacks, " ")
+
+					return iStacks < jStacks
+				}
+
+				return iVersion.GreaterThan(jVersion)
+			}
+
+			return iVal.ID < jVal.ID
+		})
+
+		fmt.Fprintf(writer, "#### Dependencies:\n| Name | Version | Stacks | Source |\n|---|---|---|---|\n")
+		for _, d := range sorted {
+			fmt.Fprintf(writer, "| %s | %s | %s | %s |\n", d.ID, d.Version, strings.Join(d.Stacks, " "), d.Source)
+		}
+		fmt.Fprintln(writer)
+	}
+
+}
+
+func (f ExtensionFormatter) Markdown(entries []ExtensionMetadata) {
+
+	fmt.Fprintf(f.writer, "## %s %s\n", entries[0].Config.Extension.Name, entries[0].Config.Extension.Version)
+	fmt.Fprintf(f.writer, "\n**ID:** `%s`\n\n", entries[0].Config.Extension.ID)
+	fmt.Fprintf(f.writer, "**Digest:** `%s`\n\n", entries[0].SHA256)
+	printExtensionImplementation(f.writer, entries[0].Config)
+
+}
+
+func (f ExtensionFormatter) JSON(entries []ExtensionMetadata) {
+	var output struct {
+		Buildpackage cargo.ExtensionConfig `json:"buildpackage"`
+	}
+
+	output.Buildpackage = entries[0].Config
+
+	_ = json.NewEncoder(f.writer).Encode(&output)
+}

--- a/internal/extension_formatter_test.go
+++ b/internal/extension_formatter_test.go
@@ -1,0 +1,203 @@
+package internal_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/paketo-buildpacks/jam/v2/internal"
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testExtensionFormatter(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		buffer    *bytes.Buffer
+		formatter internal.ExtensionFormatter
+	)
+
+	it.Before(func() {
+		buffer = bytes.NewBuffer(nil)
+		formatter = internal.NewExtensionFormatter(buffer)
+	})
+
+	context("Markdown", func() {
+		it("returns a list of dependencies", func() {
+			formatter.Markdown([]internal.ExtensionMetadata{
+				{
+					Config: cargo.ExtensionConfig{
+						Extension: cargo.ConfigExtension{
+							ID:      "paketo-community/ubi-nodejs-extension",
+							Name:    "Ubi Node.js Extension",
+							Version: "0.0.2",
+						},
+						Metadata: cargo.ConfigExtensionMetadata{
+							DefaultVersions: map[string]string{
+								"node": "20.*.*",
+							},
+							Dependencies: []cargo.ConfigExtensionMetadataDependency{
+								{
+									ID:      "node",
+									Name:    "Ubi Node Extension",
+									Source:  "paketocommunity/run-nodejs-20-ubi-base",
+									Stacks:  []string{"io.buildpacks.stacks.ubi8"},
+									Version: "20.1000",
+								},
+								{
+									ID:      "node",
+									Name:    "Ubi Node Extension",
+									Source:  "paketocommunity/run-nodejs-18-ubi-base",
+									Stacks:  []string{"io.buildpacks.stacks.ubi8"},
+									Version: "18.1000",
+								},
+								{
+									ID:      "node",
+									Name:    "Ubi Node Extension",
+									Source:  "paketocommunity/run-nodejs-16-ubi-base",
+									Stacks:  []string{"io.buildpacks.stacks.ubi8"},
+									Version: "16.1000",
+								},
+							},
+						},
+					},
+					SHA256: "sha256:manifest-sha",
+				},
+			})
+			Expect(buffer).To(ContainLines(
+				"## Ubi Node.js Extension 0.0.2",
+				"",
+				"**ID:** `paketo-community/ubi-nodejs-extension`",
+				"",
+				"**Digest:** `sha256:manifest-sha`",
+				"",
+				"#### Default Dependency Versions:",
+				"| ID | Version |",
+				"|---|---|",
+				"| node | 20.*.* |",
+				"",
+				"#### Dependencies:",
+				"| Name | Version | Stacks | Source |",
+				"|---|---|---|---|",
+				"| node | 20.1000 | io.buildpacks.stacks.ubi8 | paketocommunity/run-nodejs-20-ubi-base |",
+				"| node | 18.1000 | io.buildpacks.stacks.ubi8 | paketocommunity/run-nodejs-18-ubi-base |",
+				"| node | 16.1000 | io.buildpacks.stacks.ubi8 | paketocommunity/run-nodejs-16-ubi-base |",
+			))
+		})
+
+		context("when dependencies and default-versions are empty", func() {
+			it("returns a list of dependencies", func() {
+				formatter.Markdown([]internal.ExtensionMetadata{
+					{
+						Config: cargo.ExtensionConfig{
+							Extension: cargo.ConfigExtension{
+								ID:      "paketo-community/ubi-nodejs-extension",
+								Name:    "Ubi Node.js Extension",
+								Version: "0.0.2",
+							},
+						},
+						SHA256: "sha256:manifest-sha",
+					},
+				})
+				Expect(buffer.String()).To(Equal(`## Ubi Node.js Extension 0.0.2` +
+
+					"\n\n**ID:** `paketo-community/ubi-nodejs-extension`\n\n" +
+
+					"**Digest:** `sha256:manifest-sha`\n\n",
+				))
+			})
+		})
+
+	})
+
+	context("JSON", func() {
+		it("returns a list of dependencies", func() {
+			formatter.JSON([]internal.ExtensionMetadata{
+				{
+					Config: cargo.ExtensionConfig{
+						Extension: cargo.ConfigExtension{
+							ID:      "paketo-community/ubi-nodejs-extension",
+							Name:    "Ubi Node.js Extension",
+							Version: "0.0.2",
+						},
+						Metadata: cargo.ConfigExtensionMetadata{
+							DefaultVersions: map[string]string{
+								"node": "20.*.*",
+							},
+							Dependencies: []cargo.ConfigExtensionMetadataDependency{
+								{
+									ID:      "node",
+									Name:    "Ubi Node Extension",
+									Source:  "paketocommunity/run-nodejs-20-ubi-base",
+									Stacks:  []string{"io.buildpacks.stacks.ubi8"},
+									Version: "20.1000",
+								},
+								{
+									ID:      "node",
+									Name:    "Ubi Node Extension",
+									Source:  "paketocommunity/run-nodejs-18-ubi-base",
+									Stacks:  []string{"io.buildpacks.stacks.ubi8"},
+									Version: "18.1000",
+								},
+								{
+									ID:      "node",
+									Name:    "Ubi Node Extension",
+									Source:  "paketocommunity/run-nodejs-16-ubi-base",
+									Stacks:  []string{"io.buildpacks.stacks.ubi8"},
+									Version: "16.1000",
+								},
+							},
+						},
+					},
+					SHA256: "sha256:manifest-sha",
+				},
+			})
+			Expect(buffer.String()).To(MatchJSON(`{
+				"buildpackage": {
+				  "extension": {
+					"id": "paketo-community/ubi-nodejs-extension",
+					"name": "Ubi Node.js Extension",
+					"version": "0.0.2"
+				  },
+				  "metadata": {
+					"default-versions": {
+					  "node": "20.*.*"
+					},
+					"dependencies": [
+					  {
+						"id": "node",
+						"name": "Ubi Node Extension",
+						"source": "paketocommunity/run-nodejs-20-ubi-base",
+						"stacks": [
+						  "io.buildpacks.stacks.ubi8"
+						],
+						"version": "20.1000"
+					  },
+					  {
+						"id": "node",
+						"name": "Ubi Node Extension",
+						"source": "paketocommunity/run-nodejs-18-ubi-base",
+						"stacks": [
+						  "io.buildpacks.stacks.ubi8"
+						],
+						"version": "18.1000"
+					  },
+					  {
+						"id": "node",
+						"name": "Ubi Node Extension",
+						"source": "paketocommunity/run-nodejs-16-ubi-base",
+						"stacks": [
+						  "io.buildpacks.stacks.ubi8"
+						],
+						"version": "16.1000"
+					  }
+					]
+				  }
+				}
+			  }`))
+		})
+	})
+}

--- a/internal/extension_inspector.go
+++ b/internal/extension_inspector.go
@@ -1,0 +1,119 @@
+package internal
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+)
+
+type ExtensionInspector struct{}
+
+func NewExtensionInspector() ExtensionInspector {
+	return ExtensionInspector{}
+}
+
+type ExtensionMetadata struct {
+	Config cargo.ExtensionConfig
+	SHA256 string
+}
+
+func (i ExtensionInspector) Dependencies(path string) ([]ExtensionMetadata, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	indicesJSON, err := fetchFromArchive(tar.NewReader(file), "index.json", true)
+	if err != nil {
+		return nil, err
+	}
+
+	var index struct {
+		Manifests []struct {
+			Digest string `json:"digest"`
+		} `json:"manifests"`
+	}
+
+	// There can only be 1 image index
+	err = json.NewDecoder(indicesJSON[0]).Decode(&index)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests, err := fetchFromArchive(tar.NewReader(file), filepath.Join("blobs", "sha256", strings.TrimPrefix(index.Manifests[0].Digest, "sha256:")), true)
+	if err != nil {
+		return nil, err
+	}
+
+	buildpackageDigest := index.Manifests[0].Digest
+
+	var m struct {
+		Layers []struct {
+			Digest string `json:"digest"`
+		} `json:"layers"`
+	}
+
+	// We only support single manifest images
+	err = json.NewDecoder(manifests[0]).Decode(&m)
+	if err != nil {
+		return nil, err
+	}
+
+	var metadataCollection []ExtensionMetadata
+	for _, layer := range m.Layers {
+		_, err = file.Seek(0, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		layerBlobs, err := fetchFromArchive(tar.NewReader(file), filepath.Join("blobs", "sha256", strings.TrimPrefix(layer.Digest, "sha256:")), true)
+		if err != nil {
+			return nil, err
+		}
+
+		layerGR, err := gzip.NewReader(layerBlobs[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to read layer blob: %w", err)
+		}
+		defer layerGR.Close()
+
+		// Generally, each layer corresponds to a buildpack.
+		// But certain buildpacks are "flattened" and contain multiple buildpacks
+		// in the same layer.
+		buildpackTOMLs, err := fetchFromArchive(tar.NewReader(layerGR), "extension.toml", false)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, buildpackTOML := range buildpackTOMLs {
+			var config cargo.ExtensionConfig
+			err = cargo.DecodeExtensionConfig(buildpackTOML, &config)
+			if err != nil {
+				return nil, err
+			}
+
+			metadata := ExtensionMetadata{
+				Config: config,
+			}
+			metadataCollection = append(metadataCollection, metadata)
+		}
+	}
+
+	if len(metadataCollection) == 1 {
+		metadataCollection[0].SHA256 = buildpackageDigest
+	}
+
+	return metadataCollection, nil
+}

--- a/internal/extension_inspector.go
+++ b/internal/extension_inspector.go
@@ -89,17 +89,17 @@ func (i ExtensionInspector) Dependencies(path string) ([]ExtensionMetadata, erro
 		}
 		defer layerGR.Close()
 
-		// Generally, each layer corresponds to a buildpack.
-		// But certain buildpacks are "flattened" and contain multiple buildpacks
+		// Generally, each layer corresponds to an extension.
+		// But certain extension are "flattened" and contain multiple extension
 		// in the same layer.
-		buildpackTOMLs, err := fetchFromArchive(tar.NewReader(layerGR), "extension.toml", false)
+		extensionTOMLs, err := fetchFromArchive(tar.NewReader(layerGR), "extension.toml", false)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, buildpackTOML := range buildpackTOMLs {
+		for _, extensionTOML := range extensionTOMLs {
 			var config cargo.ExtensionConfig
-			err = cargo.DecodeExtensionConfig(buildpackTOML, &config)
+			err = cargo.DecodeExtensionConfig(extensionTOML, &config)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/extension_inspector_test.go
+++ b/internal/extension_inspector_test.go
@@ -1,0 +1,839 @@
+package internal_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/paketo-buildpacks/jam/v2/internal"
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testBuildpackInspector(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		inspector                             internal.BuildpackInspector
+		buildpackage                          string
+		contentBp1, contentBp2, contentMetaBp []byte
+	)
+
+	it.Before(func() {
+		file, err := os.CreateTemp("", "buildpackage")
+		Expect(err).NotTo(HaveOccurred())
+
+		tw := tar.NewWriter(file)
+
+		firstBuildpack := bytes.NewBuffer(nil)
+		firstBuildpackGW := gzip.NewWriter(firstBuildpack)
+		firstBuildpackTW := tar.NewWriter(firstBuildpackGW)
+
+		contentBp1 = []byte(`[buildpack]
+id = "some-buildpack"
+version = "1.2.3"
+
+[metadata.default-versions]
+some-dependency = "1.2.x"
+other-dependency = "2.3.x"
+
+[[metadata.dependencies]]
+	id = "some-dependency"
+	stacks = ["some-stack"]
+	version = "1.2.3"
+
+[[metadata.dependencies]]
+	id = "other-dependency"
+	stacks = ["other-stack"]
+	version = "2.3.4"
+
+[[stacks]]
+	id = "some-stack"
+
+[[stacks]]
+	id = "other-stack"
+`)
+
+		err = firstBuildpackTW.WriteHeader(&tar.Header{
+			Name: "./buildpack.toml",
+			Mode: 0644,
+			Size: int64(len(contentBp1)),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = firstBuildpackTW.Write(contentBp1)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(firstBuildpackTW.Close()).To(Succeed())
+		Expect(firstBuildpackGW.Close()).To(Succeed())
+
+		err = tw.WriteHeader(&tar.Header{
+			Name: "blobs/sha256/first-buildpack-sha",
+			Mode: 0644,
+			Size: int64(firstBuildpack.Len()),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = tw.Write(firstBuildpack.Bytes())
+		Expect(err).NotTo(HaveOccurred())
+
+		secondBuildpack := bytes.NewBuffer(nil)
+		secondBuildpackGW := gzip.NewWriter(secondBuildpack)
+		secondBuildpackTW := tar.NewWriter(secondBuildpackGW)
+
+		contentBp2 = []byte(`[buildpack]
+id = "other-buildpack"
+version = "2.3.4"
+
+[metadata.default-versions]
+first-dependency = "4.5.x"
+second-dependency = "5.6.x"
+
+[[metadata.dependencies]]
+	id = "first-dependency"
+	stacks = ["first-stack"]
+	version = "4.5.6"
+
+[[metadata.dependencies]]
+	id = "second-dependency"
+	stacks = ["second-stack"]
+	version = "5.6.7"
+
+[[stacks]]
+	id = "first-stack"
+
+[[stacks]]
+	id = "second-stack"
+`)
+
+		err = secondBuildpackTW.WriteHeader(&tar.Header{
+			Name: "./buildpack.toml",
+			Mode: 0644,
+			Size: int64(len(contentBp2)),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = secondBuildpackTW.Write(contentBp2)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(secondBuildpackTW.Close()).To(Succeed())
+		Expect(secondBuildpackGW.Close()).To(Succeed())
+
+		err = tw.WriteHeader(&tar.Header{
+			Name: "blobs/sha256/second-buildpack-sha",
+			Mode: 0644,
+			Size: int64(secondBuildpack.Len()),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = tw.Write(secondBuildpack.Bytes())
+		Expect(err).NotTo(HaveOccurred())
+
+		thirdBuildpack := bytes.NewBuffer(nil)
+		thirdBuildpackGW := gzip.NewWriter(thirdBuildpack)
+		thirdBuildpackTW := tar.NewWriter(thirdBuildpackGW)
+
+		contentMetaBp = []byte(`[buildpack]
+id = "meta-buildpack"
+version = "3.4.5"
+
+[[order]]
+[[order.group]]
+id = "some-buildpack"
+version = "1.2.3"
+
+[[order]]
+[[order.group]]
+id = "other-buildpack"
+version = "2.3.4"
+`)
+
+		err = thirdBuildpackTW.WriteHeader(&tar.Header{
+			Name: "./buildpack.toml",
+			Mode: 0644,
+			Size: int64(len(contentMetaBp)),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = thirdBuildpackTW.Write(contentMetaBp)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(thirdBuildpackTW.Close()).To(Succeed())
+		Expect(thirdBuildpackGW.Close()).To(Succeed())
+
+		err = tw.WriteHeader(&tar.Header{
+			Name: "blobs/sha256/third-buildpack-sha",
+			Mode: 0644,
+			Size: int64(thirdBuildpack.Len()),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = tw.Write(thirdBuildpack.Bytes())
+		Expect(err).NotTo(HaveOccurred())
+
+		manifest := bytes.NewBuffer(nil)
+		err = json.NewEncoder(manifest).Encode(map[string]interface{}{
+			"layers": []map[string]interface{}{
+				{"digest": "sha256:first-buildpack-sha"},
+				{"digest": "sha256:second-buildpack-sha"},
+				{"digest": "sha256:third-buildpack-sha"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = tw.WriteHeader(&tar.Header{
+			Name: "blobs/sha256/manifest-sha",
+			Mode: 0644,
+			Size: int64(manifest.Len()),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = tw.Write(manifest.Bytes())
+		Expect(err).NotTo(HaveOccurred())
+
+		index := bytes.NewBuffer(nil)
+		err = json.NewEncoder(index).Encode(map[string]interface{}{
+			"manifests": []map[string]interface{}{
+				{"digest": "sha256:manifest-sha"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = tw.WriteHeader(&tar.Header{
+			Name: "index.json",
+			Mode: 0644,
+			Size: int64(index.Len()),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = tw.Write(index.Bytes())
+		Expect(err).NotTo(HaveOccurred())
+
+		buildpackage = file.Name()
+
+		Expect(tw.Close()).To(Succeed())
+		Expect(file.Close()).To(Succeed())
+
+		inspector = internal.NewBuildpackInspector()
+	})
+
+	it.After(func() {
+		Expect(os.Remove(buildpackage)).To(Succeed())
+	})
+
+	context("Dependencies", func() {
+		var (
+			expectedMetadata []internal.BuildpackMetadata
+			buildpackageFlat string
+		)
+
+		it.Before(func() {
+			expectedMetadata = []internal.BuildpackMetadata{
+				{
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "some-buildpack",
+							Version: "1.2.3",
+						},
+						Metadata: cargo.ConfigMetadata{
+							Dependencies: []cargo.ConfigMetadataDependency{
+								{
+									ID:      "some-dependency",
+									Stacks:  []string{"some-stack"},
+									Version: "1.2.3",
+								},
+								{
+									ID:      "other-dependency",
+									Stacks:  []string{"other-stack"},
+									Version: "2.3.4",
+								},
+							},
+							DefaultVersions: map[string]string{
+								"some-dependency":  "1.2.x",
+								"other-dependency": "2.3.x",
+							},
+						},
+						Stacks: []cargo.ConfigStack{
+							{ID: "some-stack"},
+							{ID: "other-stack"},
+						},
+					},
+				},
+				{
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "other-buildpack",
+							Version: "2.3.4",
+						},
+						Metadata: cargo.ConfigMetadata{
+							Dependencies: []cargo.ConfigMetadataDependency{
+								{
+									ID:      "first-dependency",
+									Stacks:  []string{"first-stack"},
+									Version: "4.5.6",
+								},
+								{
+									ID:      "second-dependency",
+									Stacks:  []string{"second-stack"},
+									Version: "5.6.7",
+								},
+							},
+							DefaultVersions: map[string]string{
+								"first-dependency":  "4.5.x",
+								"second-dependency": "5.6.x",
+							},
+						},
+						Stacks: []cargo.ConfigStack{
+							{ID: "first-stack"},
+							{ID: "second-stack"},
+						},
+					},
+				},
+				{
+					Config: cargo.Config{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "meta-buildpack",
+							Version: "3.4.5",
+						},
+						Order: []cargo.ConfigOrder{
+							{
+								Group: []cargo.ConfigOrderGroup{
+									{
+										ID:      "some-buildpack",
+										Version: "1.2.3",
+									},
+								},
+							},
+							{
+								Group: []cargo.ConfigOrderGroup{
+									{
+										ID:      "other-buildpack",
+										Version: "2.3.4",
+									},
+								},
+							},
+						},
+					},
+					SHA256: "sha256:manifest-sha",
+				},
+			}
+		})
+
+		context("Unflattened buildpack", func() {
+			it("returns a list of dependencies", func() {
+				configs, err := inspector.Dependencies(buildpackage)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configs).To(Equal(expectedMetadata))
+			})
+		})
+
+		context("Flattened buildpack", func() {
+			it.Before(func() {
+				/* Flattened buildpackage, but with the same buildpack metadata as the unflattened */
+				fileFlat, err := os.CreateTemp("", "buildpackage-flattened")
+				Expect(err).NotTo(HaveOccurred())
+
+				twf := tar.NewWriter(fileFlat)
+
+				flatLayer := bytes.NewBuffer(nil)
+				flatLayerGW := gzip.NewWriter(flatLayer)
+				flatLayerTW := tar.NewWriter(flatLayerGW)
+
+				err = flatLayerTW.WriteHeader(&tar.Header{
+					Name: "./buildpack-one/buildpack.toml",
+					Mode: 0644,
+					Size: int64(len(contentBp1)),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = flatLayerTW.Write(contentBp1)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = flatLayerTW.WriteHeader(&tar.Header{
+					Name: "./buildpack-two/buildpack.toml",
+					Mode: 0644,
+					Size: int64(len(contentBp2)),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = flatLayerTW.Write(contentBp2)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = flatLayerTW.WriteHeader(&tar.Header{
+					Name: "./buildpack-three-meta/buildpack.toml",
+					Mode: 0644,
+					Size: int64(len(contentMetaBp)),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = flatLayerTW.Write(contentMetaBp)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(flatLayerTW.Close()).To(Succeed())
+				Expect(flatLayerGW.Close()).To(Succeed())
+
+				err = twf.WriteHeader(&tar.Header{
+					Name: "blobs/sha256/all-buildpacks-flattened-layer-sha",
+					Mode: 0644,
+					Size: int64(flatLayer.Len()),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = twf.Write(flatLayer.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				manifestFlat := bytes.NewBuffer(nil)
+				err = json.NewEncoder(manifestFlat).Encode(map[string]interface{}{
+					"layers": []map[string]interface{}{
+						{"digest": "sha256:all-buildpacks-flattened-layer-sha"},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = twf.WriteHeader(&tar.Header{
+					Name: "blobs/sha256/manifest-sha",
+					Mode: 0644,
+					Size: int64(manifestFlat.Len()),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = twf.Write(manifestFlat.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				indexFlat := bytes.NewBuffer(nil)
+				err = json.NewEncoder(indexFlat).Encode(map[string]interface{}{
+					"manifests": []map[string]interface{}{
+						{"digest": "sha256:manifest-sha"},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = twf.WriteHeader(&tar.Header{
+					Name: "index.json",
+					Mode: 0644,
+					Size: int64(indexFlat.Len()),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = twf.Write(indexFlat.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				buildpackageFlat = fileFlat.Name()
+
+				Expect(twf.Close()).To(Succeed())
+				Expect(fileFlat.Close()).To(Succeed())
+
+				inspector = internal.NewBuildpackInspector()
+			})
+
+			it.After(func() {
+				Expect(os.Remove(buildpackageFlat)).To(Succeed())
+			})
+
+			it("returns a list of dependencies", func() {
+				configs, err := inspector.Dependencies(buildpackageFlat)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configs).To(Equal(expectedMetadata))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the file cannot be opened", func() {
+				it("returns an error", func() {
+					_, err := inspector.Dependencies("no-real-file")
+					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+				})
+			})
+
+			context("when the index.json does not exist", func() {
+				it.Before(func() {
+					err := os.Truncate(buildpackage, 0)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError("failed to fetch archived file index.json"))
+				})
+			})
+
+			context("when the index.json is malformed", func() {
+				it.Before(func() {
+					file, err := os.OpenFile(buildpackage, os.O_TRUNC|os.O_RDWR, 0644)
+					Expect(err).NotTo(HaveOccurred())
+
+					tw := tar.NewWriter(file)
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "index.json",
+						Mode: 0644,
+						Size: 3,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write([]byte(`%%%`))
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(tw.Close()).To(Succeed())
+					Expect(file.Close()).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError(ContainSubstring("invalid character '%'")))
+				})
+			})
+
+			context("when the manifest does not exist", func() {
+				it.Before(func() {
+					file, err := os.OpenFile(buildpackage, os.O_TRUNC|os.O_RDWR, 0644)
+					Expect(err).NotTo(HaveOccurred())
+
+					tw := tar.NewWriter(file)
+
+					index := bytes.NewBuffer(nil)
+					err = json.NewEncoder(index).Encode(map[string]interface{}{
+						"manifests": []map[string]interface{}{
+							{"digest": "sha256:manifest-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "index.json",
+						Mode: 0644,
+						Size: int64(index.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(index.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(tw.Close()).To(Succeed())
+					Expect(file.Close()).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError("failed to fetch archived file blobs/sha256/manifest-sha"))
+				})
+			})
+
+			context("when the manifest is malformed", func() {
+				it.Before(func() {
+					file, err := os.OpenFile(buildpackage, os.O_TRUNC|os.O_RDWR, 0644)
+					Expect(err).NotTo(HaveOccurred())
+
+					tw := tar.NewWriter(file)
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/manifest-sha",
+						Mode: 0644,
+						Size: 3,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write([]byte(`%%%`))
+					Expect(err).NotTo(HaveOccurred())
+
+					index := bytes.NewBuffer(nil)
+					err = json.NewEncoder(index).Encode(map[string]interface{}{
+						"manifests": []map[string]interface{}{
+							{"digest": "sha256:manifest-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "index.json",
+						Mode: 0644,
+						Size: int64(index.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(index.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(tw.Close()).To(Succeed())
+					Expect(file.Close()).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError(ContainSubstring("invalid character '%'")))
+				})
+			})
+
+			context("when the buildpack blob does not exist", func() {
+				it.Before(func() {
+					file, err := os.OpenFile(buildpackage, os.O_TRUNC|os.O_RDWR, 0644)
+					Expect(err).NotTo(HaveOccurred())
+
+					tw := tar.NewWriter(file)
+
+					manifest := bytes.NewBuffer(nil)
+					err = json.NewEncoder(manifest).Encode(map[string]interface{}{
+						"layers": []map[string]interface{}{
+							{"digest": "sha256:buildpack-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/manifest-sha",
+						Mode: 0644,
+						Size: int64(manifest.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(manifest.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					index := bytes.NewBuffer(nil)
+					err = json.NewEncoder(index).Encode(map[string]interface{}{
+						"manifests": []map[string]interface{}{
+							{"digest": "sha256:manifest-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "index.json",
+						Mode: 0644,
+						Size: int64(index.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(index.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(tw.Close()).To(Succeed())
+					Expect(file.Close()).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError("failed to fetch archived file blobs/sha256/buildpack-sha"))
+				})
+			})
+
+			context("when the buildpack blob is not a gziped tar", func() {
+				it.Before(func() {
+					file, err := os.OpenFile(buildpackage, os.O_TRUNC|os.O_RDWR, 0644)
+					Expect(err).NotTo(HaveOccurred())
+
+					tw := tar.NewWriter(file)
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/buildpack-sha",
+						Mode: 0644,
+						Size: 3,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write([]byte(`%%%`))
+					Expect(err).NotTo(HaveOccurred())
+
+					manifest := bytes.NewBuffer(nil)
+					err = json.NewEncoder(manifest).Encode(map[string]interface{}{
+						"layers": []map[string]interface{}{
+							{"digest": "sha256:buildpack-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/manifest-sha",
+						Mode: 0644,
+						Size: int64(manifest.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(manifest.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					index := bytes.NewBuffer(nil)
+					err = json.NewEncoder(index).Encode(map[string]interface{}{
+						"manifests": []map[string]interface{}{
+							{"digest": "sha256:manifest-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "index.json",
+						Mode: 0644,
+						Size: int64(index.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(index.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(tw.Close()).To(Succeed())
+					Expect(file.Close()).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError("failed to read layer blob: unexpected EOF"))
+				})
+			})
+
+			context("when the buildpack blob does not contain a buildpack.toml", func() {
+				it.Before(func() {
+					file, err := os.OpenFile(buildpackage, os.O_TRUNC|os.O_RDWR, 0644)
+					Expect(err).NotTo(HaveOccurred())
+
+					tw := tar.NewWriter(file)
+
+					buildpack := bytes.NewBuffer(nil)
+					buildpackGW := gzip.NewWriter(buildpack)
+					buildpackTW := tar.NewWriter(buildpackGW)
+
+					Expect(buildpackTW.Close()).To(Succeed())
+					Expect(buildpackGW.Close()).To(Succeed())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/buildpack-sha",
+						Mode: 0644,
+						Size: int64(buildpack.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(buildpack.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					manifest := bytes.NewBuffer(nil)
+					err = json.NewEncoder(manifest).Encode(map[string]interface{}{
+						"layers": []map[string]interface{}{
+							{"digest": "sha256:buildpack-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/manifest-sha",
+						Mode: 0644,
+						Size: int64(manifest.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(manifest.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					index := bytes.NewBuffer(nil)
+					err = json.NewEncoder(index).Encode(map[string]interface{}{
+						"manifests": []map[string]interface{}{
+							{"digest": "sha256:manifest-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "index.json",
+						Mode: 0644,
+						Size: int64(index.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(index.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(tw.Close()).To(Succeed())
+					Expect(file.Close()).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError("failed to fetch archived file buildpack.toml"))
+				})
+			})
+
+			context("when the buildpack.toml is malformed", func() {
+				it.Before(func() {
+					file, err := os.OpenFile(buildpackage, os.O_TRUNC|os.O_RDWR, 0644)
+					Expect(err).NotTo(HaveOccurred())
+
+					tw := tar.NewWriter(file)
+
+					buildpack := bytes.NewBuffer(nil)
+					buildpackGW := gzip.NewWriter(buildpack)
+					buildpackTW := tar.NewWriter(buildpackGW)
+
+					err = buildpackTW.WriteHeader(&tar.Header{
+						Name: "./buildpack.toml",
+						Mode: 0644,
+						Size: 3,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = buildpackTW.Write([]byte(`%%%`))
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(buildpackTW.Close()).To(Succeed())
+					Expect(buildpackGW.Close()).To(Succeed())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/buildpack-sha",
+						Mode: 0644,
+						Size: int64(buildpack.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(buildpack.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					manifest := bytes.NewBuffer(nil)
+					err = json.NewEncoder(manifest).Encode(map[string]interface{}{
+						"layers": []map[string]interface{}{
+							{"digest": "sha256:buildpack-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "blobs/sha256/manifest-sha",
+						Mode: 0644,
+						Size: int64(manifest.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(manifest.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					index := bytes.NewBuffer(nil)
+					err = json.NewEncoder(index).Encode(map[string]interface{}{
+						"manifests": []map[string]interface{}{
+							{"digest": "sha256:manifest-sha"},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = tw.WriteHeader(&tar.Header{
+						Name: "index.json",
+						Mode: 0644,
+						Size: int64(index.Len()),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = tw.Write(index.Bytes())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(tw.Close()).To(Succeed())
+					Expect(file.Close()).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := inspector.Dependencies(buildpackage)
+					Expect(err).To(MatchError(ContainSubstring("got '%' instead")))
+				})
+			})
+		})
+	})
+}

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -24,6 +24,7 @@ func TestUnitInternal(t *testing.T) {
 	suite("BuilderConfig", testBuilderConfig)
 	suite("BuildpackConfig", testBuildpackConfig)
 	suite("BuildpackInspector", testBuildpackInspector)
+	suite("ExtensionInspector", testExtensionInspector)
 	suite("DependencyCacher", testDependencyCacher)
 	suite("Dependency", testDependency)
 	suite("FileBundler", testFileBundler)

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -29,6 +29,7 @@ func TestUnitInternal(t *testing.T) {
 	suite("Dependency", testDependency)
 	suite("FileBundler", testFileBundler)
 	suite("Formatter", testFormatter)
+	suite("ExtensionFormatter", testExtensionFormatter)
 	suite("Image", testImage)
 	suite("PrePackager", testPrePackager)
 	suite("PackageConfig", testPackageConfig)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adding extension command for summarizing a buildpackage.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This is used when we want to print info of an extension in a json or markdown format. Mostly used on the release notes of an extension.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
