### PR TITLE
Adding Command [publish-image] for publishing a single image 

### DIFF
--- a/commands/publish_image.go
+++ b/commands/publish_image.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/paketo-buildpacks/jam/v2/internal/ihop"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(publishImage())
+}
+
+type publishImageFlags struct {
+	imageArchive   string
+	imageReference string
+}
+
+func publishImage() *cobra.Command {
+	flags := &publishImageFlags{}
+	cmd := &cobra.Command{
+		Use:   "publish-image",
+		Short: "publish-image",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return publishImageRun(*flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.imageArchive, "image-archive", "", "path to the OCI image archive (required)")
+	cmd.Flags().StringVar(&flags.imageReference, "image-ref", "", "reference that specifies where to publish the image (required)")
+
+	err := cmd.MarkFlagRequired("image-archive")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to mark image-archive flag as required")
+	}
+
+	err = cmd.MarkFlagRequired("image-ref")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to mark image-ref flag as required")
+	}
+
+	return cmd
+}
+
+func publishImageRun(flags publishImageFlags) error {
+	logger := scribe.NewLogger(os.Stdout)
+
+	scratch, err := os.MkdirTemp("", "")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(scratch)
+
+	tmpExtractedImage := filepath.Join(scratch, "extracted_image")
+	err = extractTar(flags.imageArchive, tmpExtractedImage)
+	if err != nil {
+		return err
+	}
+
+	client, err := ihop.NewClient(scratch)
+	if err != nil {
+		return err
+	}
+
+	logger.Process("Uploading image to %s", flags.imageReference)
+	err = client.Upload(flags.imageReference, tmpExtractedImage)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -28,6 +28,7 @@ func TestJam(t *testing.T) {
 	suite := spec.New("jam", spec.Report(report.Terminal{}))
 	suite("Errors", testErrors)
 	suite("create-stack", testCreateStack)
+	suite("publish-image", testPublishImage)
 	suite("pack", testPack)
 	suite("summarize", testSummarize)
 	suite("update-builder", testUpdateBuilder)

--- a/integration/publish_image_test.go
+++ b/integration/publish_image_test.go
@@ -1,0 +1,78 @@
+package integration_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega/gexec"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testPublishImage(t *testing.T, context spec.G, it spec.S) {
+	var (
+		withT      = NewWithT(t)
+		Expect     = withT.Expect
+		Eventually = withT.Eventually
+
+		tmpDir string
+	)
+
+	it.Before(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "")
+		Expect(err).NotTo(HaveOccurred())
+
+		buffer := bytes.NewBuffer(nil)
+		command := exec.Command(
+			path, "create-stack",
+			"--config", filepath.Join("testdata", "example-stack", "stack.toml"),
+			"--build-output", filepath.Join(tmpDir, "build.oci"),
+			"--run-output", filepath.Join(tmpDir, "run.oci"),
+			"--secret", "some-secret=my-secret-value",
+		)
+		session, err := gexec.Start(command, buffer, buffer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session).Should(gexec.Exit(0), buffer.String)
+
+		archive, err := os.Open(filepath.Join(tmpDir, "run.oci"))
+		Expect(err).NotTo(HaveOccurred())
+		defer archive.Close()
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	context("When it tries to push an image to a non existence registry", func() {
+		it("It fails with an error message", func() {
+
+			buffer := bytes.NewBuffer(nil)
+			command := exec.Command(
+				path, "publish-image",
+				"--image-ref", "registry-does-not-exist/image-name:latest",
+				"--image-archive", filepath.Join(tmpDir, "run.oci"),
+			)
+			session, err := gexec.Start(command, buffer, buffer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(1), buffer.String)
+
+			fmt.Println(buffer.String())
+
+			Expect(buffer.String()).To(ContainSubstring(
+				"Uploading image to registry-does-not-exist/image-name:latest",
+			))
+
+			Expect(buffer.String()).To(ContainSubstring(
+				"unexpected status code 401 Unauthorized",
+			))
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds an extra command called `publish-image`, which enables publishing one image at a time compared to the `publish-stack` which publishes two images at a time (the build and the run image of the stack). This functionality is important for two reasons:
* On the `ubi` stacks, we don't have a build image for each stack but only for the default stack (where the extension runs). Therefore, currently, we are unable to push only the `run` image of the stack as the `jam` cli forces us to push both  `run` and `build` image.
* The stacks are getting deprecated, so publishing a build and a run image together at the same time, might not always be the use case for the rest of the stacks in the future

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
