### PR TITLE
Setting alpine to a specific tag version

### DIFF
--- a/integration/matchers/have_directory_test.go
+++ b/integration/matchers/have_directory_test.go
@@ -22,7 +22,7 @@ func testHaveDirectory(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		ref, err := name.ParseReference("alpine:latest")
+		ref, err := name.ParseReference("alpine:3.19")
 		Expect(err).NotTo(HaveOccurred())
 
 		image, err = daemon.Image(ref)

--- a/integration/matchers/have_file_test.go
+++ b/integration/matchers/have_file_test.go
@@ -22,7 +22,7 @@ func testHaveFile(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		ref, err := name.ParseReference("alpine:latest")
+		ref, err := name.ParseReference("alpine:3.19")
 		Expect(err).NotTo(HaveOccurred())
 
 		image, err = daemon.Image(ref)

--- a/integration/matchers/have_file_with_content_test.go
+++ b/integration/matchers/have_file_with_content_test.go
@@ -22,7 +22,7 @@ func testHaveFileWithContent(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		ref, err := name.ParseReference("alpine:latest")
+		ref, err := name.ParseReference("alpine:3.19")
 		Expect(err).NotTo(HaveOccurred())
 
 		image, err = daemon.Image(ref)

--- a/integration/matchers/init_test.go
+++ b/integration/matchers/init_test.go
@@ -22,7 +22,7 @@ func TestMatchers(t *testing.T) {
 	client, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	Expect(err).NotTo(HaveOccurred())
 
-	stream, err := client.ImagePull(context.Background(), "alpine:latest", types.ImagePullOptions{})
+	stream, err := client.ImagePull(context.Background(), "alpine:3.19", types.ImagePullOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	_, err = io.Copy(io.Discard, stream)
@@ -36,6 +36,6 @@ func TestMatchers(t *testing.T) {
 	suite("MatchTomlContent", testMatchTomlContent)
 	suite.Run(t)
 
-	_, err = client.ImageRemove(context.Background(), "alpine:latest", types.ImageRemoveOptions{Force: true})
+	_, err = client.ImageRemove(context.Background(), "alpine:3.19", types.ImageRemoveOptions{Force: true})
 	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Currently, the tests fail due to alpine has moved the `/etc/os-release` file under the `/usr/lib/os-release` and, in place of the `/etc/os-release`, have replaced it with a symlink pointing to `/usr/lib/os-release.` 
Due to this movement of the file, the `matchers` are unable to match the content over a symlink.

https://github.com/paketo-buildpacks/jam/blob/71948ddc40ad4c170894625cce4e29c5b3373d14/integration/matchers/have_file_with_content_test.go#L33-L41

This PR sticks alpine to the last image that the file hasnt moved and replaced with a symlink (version 3.19)

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
