### PR TITLE
Drop strict checking for file vs directory in layers.

### DIFF
--- a/internal/ihop/image.go
+++ b/internal/ihop/image.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -18,11 +17,6 @@ func findFile(image v1.Image, filepath string) (*tar.Header, io.Reader, error) {
 	layers, err := image.Layers()
 	if err != nil {
 		return nil, nil, err
-	}
-
-	expectDir := false
-	if strings.HasSuffix(filepath, "/") {
-		expectDir = true
 	}
 
 	for i := len(layers) - 1; i >= 0; i-- {
@@ -55,11 +49,6 @@ func findFile(image v1.Image, filepath string) (*tar.Header, io.Reader, error) {
 
 			if strings.Trim(headerName, "/") == strings.Trim(filepath, "/") {
 				found = true
-
-				if expectDir && !strings.HasSuffix(headerName, "/") {
-					return nil, nil, fmt.Errorf("file type mismatch for %s - expected directory, got regular file", filepath)
-
-				}
 
 				if hdr.Typeflag == tar.TypeSymlink {
 					header, reader, err = findFile(image, path.Join(path.Dir(filepath), hdr.Linkname))


### PR DESCRIPTION
This follows on from #379 -  there are OS images where `/etc` (and other directories) are listed as a regular file, not a directory, even though it is actually a directory on the filesystem, and where this strict checking results in a false negative (i.e. it fails the build process when actually the stack would be built successfully).

There is a slight risk that this change would result in a false positive - i.e. a stack was reported as successfully being built but that the filesystem was incorrect. However, I think in reality this would fail when we tried to modify files underneath the directory (`/etc` or others) because those files cannot exist if the directory was truly a regular file, not a directory.