### PR TITLE
Support targets in buildpack.toml and package.toml

### DIFF
--- a/internal/buildpack_config.go
+++ b/internal/buildpack_config.go
@@ -8,10 +8,12 @@ import (
 )
 
 type BuildpackConfig struct {
-	API       interface{}            `toml:"api"`
-	Buildpack interface{}            `toml:"buildpack"`
-	Metadata  interface{}            `toml:"metadata"`
-	Order     []BuildpackConfigOrder `toml:"order"`
+	API       interface{}             `toml:"api"`
+	Buildpack interface{}             `toml:"buildpack"`
+	Metadata  interface{}             `toml:"metadata"`
+	Order     []BuildpackConfigOrder  `toml:"order"`
+	Stacks    []BuildpackConfigStack  `toml:"stacks,omitempty"`
+	Targets   []BuildpackConfigTarget `toml:"targets,omitempty"`
 }
 
 type BuildpackConfigOrder struct {
@@ -22,6 +24,16 @@ type BuildpackConfigOrderGroup struct {
 	ID       string `toml:"id"`
 	Version  string `toml:"version,omitempty"`
 	Optional bool   `toml:"optional,omitempty"`
+}
+
+type BuildpackConfigStack struct {
+	ID     string   `toml:"id"`
+	Mixins []string `toml:"mixins,omitempty"`
+}
+
+type BuildpackConfigTarget struct {
+	OS   string `toml:"os,omitempty"`
+	Arch string `toml:"arch,omitempty"`
 }
 
 func ParseBuildpackConfig(path string) (BuildpackConfig, error) {

--- a/internal/buildpack_config_test.go
+++ b/internal/buildpack_config_test.go
@@ -55,6 +55,17 @@ func testBuildpackConfig(t *testing.T, context spec.G, it spec.S) {
 						id = "some-repository/other-buildpack-id"
 						version = "0.1.0"
 						optional = true
+
+				[[stacks]]
+					id = "*"
+
+				[[targets]]
+					os = "linux"
+					arch = "amd64"
+
+				[[targets]]
+					os = "linux"
+					arch = "arm64"
 			`)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -107,6 +118,21 @@ func testBuildpackConfig(t *testing.T, context spec.G, it spec.S) {
 								Optional: true,
 							},
 						},
+					},
+				},
+				Stacks: []internal.BuildpackConfigStack{
+					{
+						ID: "*",
+					},
+				},
+				Targets: []internal.BuildpackConfigTarget{
+					{
+						OS:   "linux",
+						Arch: "amd64",
+					},
+					{
+						OS:   "linux",
+						Arch: "arm64",
 					},
 				},
 			}))

--- a/internal/package_config.go
+++ b/internal/package_config.go
@@ -12,10 +12,16 @@ import (
 type PackageConfig struct {
 	Buildpack    interface{}               `toml:"buildpack"`
 	Dependencies []PackageConfigDependency `toml:"dependencies"`
+	Targets      []PackageConfigTarget     `toml:"targets,omitempty"`
 }
 
 type PackageConfigDependency struct {
 	URI string `toml:"uri"`
+}
+
+type PackageConfigTarget struct {
+	OS   string `toml:"os,omitempty"`
+	Arch string `toml:"arch,omitempty"`
 }
 
 // Note: this is to support that buildpackages can refer to this field as `image` or `uri`.

--- a/internal/package_config_test.go
+++ b/internal/package_config_test.go
@@ -39,6 +39,14 @@ func testPackageConfig(t *testing.T, context spec.G, it spec.S) {
 
 				[[dependencies]]
 				uri = "urn:cnb:registry:some-registry/some-repository/final-buildpack-id@0.1.0"
+
+				[[targets]]
+					os = "linux"
+					arch = "amd64"
+
+				[[targets]]
+					os = "linux"
+					arch = "arm64"
 			`)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -61,6 +69,10 @@ func testPackageConfig(t *testing.T, context spec.G, it spec.S) {
 					{URI: "some-registry/some-repository/some-buildpack-id:0.20.1"},
 					{URI: "some-registry/some-repository/other-buildpack-id:0.1.0"},
 					{URI: "urn:cnb:registry:some-registry/some-repository/final-buildpack-id@0.1.0"},
+				},
+				Targets: []internal.PackageConfigTarget{
+					{OS: "linux", Arch: "amd64"},
+					{OS: "linux", Arch: "arm64"},
 				},
 			}))
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This change is needed to support multi-arch buildpacks. It does the following:

* Supports stacks and targets in buildpack.toml
* Supports targets in package.toml

Unit tests were updated to verify change works as expected.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Without this change the targets (and stacks) table is removed when jam is used to update buildpack.toml or package.toml files. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
