### PR TITLE
Only move offline dependencies into platform-specific dir when bin executables exists for that platform

### DIFF
--- a/integration/pack_test.go
+++ b/integration/pack_test.go
@@ -645,6 +645,9 @@ func testPack(t *testing.T, context spec.G, it spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(cargo.EncodeConfig(bpTomlWriter, config)).To(Succeed())
+
+					t.Setenv("BP_OS", "linux")
+					t.Setenv("BP_ARCH", "amd64")
 				})
 
 				it.After(func() {


### PR DESCRIPTION

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Only move offline dependencies into platform-specific dir when bin executables exists for that platform are specified in the include-files list.

## Use Cases
<!-- An explanation of the use cases your change enables -->
pack has some logic to check if the platform-specific directory exists in the root of the given buildpack directory. It will use the platform-specific directory if it exists, even if the executables are not present. This change prevents the creation of the directory for single-architecture buildpacks for backward compatibility.

Relevant links below:
https://github.com/buildpacks/pack/pull/2086
https://github.com/buildpacks/pack/blob/58cb8935ef17e65323b3fae8a81e426ab105cab2/pkg/client/package_buildpack.go#L141
https://github.com/buildpacks/pack/blob/58cb8935ef17e65323b3fae8a81e426ab105cab2/pkg/buildpack/multi_architecture_helper.go#L90

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
