### PR TITLE
Deprecate update-buildpack --no-cnb-registry flag

### DIFF
--- a/integration/update_buildpack_test.go
+++ b/integration/update_buildpack_test.go
@@ -31,7 +31,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 		buildpackDir string
 	)
 
-	context("when updating buildpacks it uses the CNB registry by default", func() {
+	context("when updating cnb registry image refs", func() {
 		it.Before(func() {
 			goRef, err := name.ParseReference("index.docker.io/paketobuildpacks/go-dist")
 			Expect(err).ToNot(HaveOccurred())
@@ -157,6 +157,19 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 				case "/v2/some-repository/nonexistent-labels-id/manifests/0.2.0":
 					w.WriteHeader(http.StatusBadRequest)
 
+				case "/v2/paketo-buildpacks/go-dist/tags/list":
+					w.WriteHeader(http.StatusOK)
+					_, err := fmt.Fprintln(w, `{
+						  "tags": [
+								"0.0.10",
+								"0.20.1",
+								"0.20.12",
+								"0.21.0",
+								"latest"
+							]
+					}`)
+					Expect(err).NotTo(HaveOccurred())
+
 				default:
 					t.Fatalf("unknown path: %s", req.URL.Path)
 				}
@@ -202,10 +215,10 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 				uri = "build/buildpack.tgz"
 
 				[[dependencies]]
-				uri = "docker://REGISTRY-URI/paketobuildpacks/mri:0.2.0"
+				uri = "urn:cnb:registry:paketo-buildpacks/mri@0.2.0"
 
 				[[dependencies]]
-				uri = "docker://REGISTRY-URI/paketo-buildpacks/go-dist:0.20.1"
+				uri = "urn:cnb:registry:paketo-buildpacks/go-dist@0.20.1"
 
 				[[dependencies]]
 				uri = "urn:cnb:registry:paketo-buildpacks/node-engine@0.1.0"
@@ -613,7 +626,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("updating non-cnb registry image refs", func() {
+	context("when updating non-cnb registry image refs", func() {
 		it.Before(func() {
 			goRef, err := name.ParseReference("index.docker.io/paketobuildpacks/go-dist")
 			Expect(err).ToNot(HaveOccurred())
@@ -811,7 +824,6 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 				"update-buildpack",
 				"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
 				"--package-file", filepath.Join(buildpackDir, "package.toml"),
-				"--no-cnb-registry",
 			)
 
 			buffer := gbytes.NewBuffer()
@@ -877,7 +889,6 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 					"update-buildpack",
 					"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
 					"--package-file", filepath.Join(buildpackDir, "package.toml"),
-					"--no-cnb-registry",
 					"--patch-only",
 				)
 
@@ -975,7 +986,6 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 						"update-buildpack",
 						"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
 						"--package-file", filepath.Join(buildpackDir, "package.toml"),
-						"--no-cnb-registry",
 					)
 
 					buffer := gbytes.NewBuffer()
@@ -1023,7 +1033,6 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 						"update-buildpack",
 						"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
 						"--package-file", filepath.Join(buildpackDir, "package.toml"),
-						"--no-cnb-registry",
 					)
 
 					buffer := gbytes.NewBuffer()
@@ -1072,7 +1081,6 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 						"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
 						"--package-file", filepath.Join(buildpackDir, "package.toml"),
 						"--patch-only",
-						"--no-cnb-registry",
 					)
 
 					buffer := gbytes.NewBuffer()


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

 This change deprecates the `jam update-buildpack` `--no-cnb-registry` flag so that both cnb and non-cnb registry URIs are supported by default. A warning is printed to STDERR if the users passed the `--no-cnb-registry` flag letting them know it is deprecated and ignored.

This change essentially reverts https://github.com/paketo-buildpacks/jam/pull/44, but it does so in a way that does not break existing workflows so they can be updated independently.

Current GitHub workflows capture the output (STDOUT) so the warning message, which is printed to STDERR, is not a breaking change.

## Use Cases
<!-- An explanation of the use cases your change enables -->
In order to support multi-arch composite buildpacks we must use non-cnb registry dependency URIs. `jam` currently converts all dependencies to cnb-registry URIs by default which causes failures during packaging.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
