### PR TITLE
Adding --no-stack-id flag for removing the stack id metadata from the base images

### DIFF
--- a/commands/create_stack.go
+++ b/commands/create_stack.go
@@ -25,6 +25,7 @@ type createStackFlags struct {
 	buildReference string
 	runReference   string
 	labels         []string
+	noStackId      bool
 }
 
 func createStack() *cobra.Command {
@@ -45,6 +46,7 @@ func createStack() *cobra.Command {
 	cmd.Flags().StringVar(&flags.buildReference, "build-ref", "", "reference that specifies where to publish the build image (required)")
 	cmd.Flags().StringVar(&flags.runReference, "run-ref", "", "reference that specifies where to publish the run image (required)")
 	cmd.Flags().StringSliceVar(&flags.labels, "label", nil, "additional image label to be added to build and run image")
+	cmd.Flags().BoolVar(&flags.noStackId, "no-stack-id", false, "do not include a stack ID in the build and run image")
 
 	err := cmd.MarkFlagRequired("config")
 	if err != nil {
@@ -73,7 +75,7 @@ func createStackRun(flags createStackFlags) error {
 		logger.Process("WARNING: The --unbuffered flag is deprecated. You can safely remove it.")
 	}
 
-	definition, err := ihop.NewDefinitionFromFile(flags.config, flags.secrets...)
+	definition, err := ihop.NewDefinitionFromFile(flags.config, flags.noStackId, flags.secrets...)
 	if err != nil {
 		return err
 	}
@@ -105,7 +107,7 @@ func createStackRun(flags createStackFlags) error {
 	builder := ihop.NewBuilder(client, ihop.Cataloger{}, runtime.NumCPU())
 	creator := ihop.NewCreator(client, builder, ihop.UserLayerCreator{}, ihop.SBOMLayerCreator{}, ihop.OsReleaseLayerCreator{Def: definition}, time.Now, logger)
 
-	stack, err := creator.Execute(definition)
+	stack, err := creator.Execute(definition, flags.noStackId)
 	if err != nil {
 		return err
 	}

--- a/internal/ihop/creator.go
+++ b/internal/ihop/creator.go
@@ -56,14 +56,14 @@ func NewCreator(docker ImageClient, builder ImageBuilder, userLayerCreator, sbom
 }
 
 // Execute builds a Stack using the given Definition.
-func (c Creator) Execute(def Definition) (Stack, error) {
+func (c Creator) Execute(def Definition, noStackId bool) (Stack, error) {
 	c.logger.Title("Building %s", def.ID)
 
 	var stack Stack
 	for _, platform := range def.Platforms {
 		c.logger.Process("Building on %s", platform)
 
-		build, run, err := c.create(def, platform)
+		build, run, err := c.create(def, platform, noStackId)
 		if err != nil {
 			return Stack{}, err
 		}
@@ -75,7 +75,7 @@ func (c Creator) Execute(def Definition) (Stack, error) {
 	return stack, nil
 }
 
-func (c Creator) create(def Definition, platform string) (Image, Image, error) {
+func (c Creator) create(def Definition, platform string, noStackId bool) (Image, Image, error) {
 	c.logger.Subprocess("Building base images")
 
 	// invoke the builder to start the build process for the build and run images
@@ -105,17 +105,19 @@ func (c Creator) create(def Definition, platform string) (Image, Image, error) {
 	c.logger.Action("Adding CNB_* environment variables")
 	build.Env = append(build.Env, fmt.Sprintf("CNB_USER_ID=%d", def.Build.UID))
 	build.Env = append(build.Env, fmt.Sprintf("CNB_GROUP_ID=%d", def.Build.GID))
-	build.Env = append(build.Env, fmt.Sprintf("CNB_STACK_ID=%s", def.ID))
+	if !noStackId {
+		build.Env = append(build.Env, fmt.Sprintf("CNB_STACK_ID=%s", def.ID))
+	}
 
 	// update the base build image with common configuration metadata
-	build, err = c.mutate(build, def, def.Build, buildSBOM, packages.Intersection, packages.BuildComplement, timestamp)
+	build, err = c.mutate(build, def, def.Build, buildSBOM, packages.Intersection, packages.BuildComplement, timestamp, noStackId)
 	if err != nil {
 		return Image{}, Image{}, err
 	}
 
 	c.logger.Subprocess("run: Decorating base image")
 	// update the base run image with common configuration metadata
-	run, err = c.mutate(run, def, def.Run, runSBOM, packages.Intersection, packages.RunComplement, timestamp)
+	run, err = c.mutate(run, def, def.Run, runSBOM, packages.Intersection, packages.RunComplement, timestamp, noStackId)
 	if err != nil {
 		return Image{}, Image{}, err
 	}
@@ -162,10 +164,12 @@ func (c Creator) create(def Definition, platform string) (Image, Image, error) {
 	return build, run, nil
 }
 
-func (c Creator) mutate(image Image, def Definition, imageDef DefinitionImage, sbom SBOM, intersection, complement []string, now time.Time) (Image, error) {
+func (c Creator) mutate(image Image, def Definition, imageDef DefinitionImage, sbom SBOM, intersection, complement []string, now time.Time, noStackId bool) (Image, error) {
 	// add the common CNB labels to the given image
 	c.logger.Action("Adding io.buildpacks.stack.* labels")
-	image.Labels["io.buildpacks.stack.id"] = def.ID
+	if !noStackId {
+		image.Labels["io.buildpacks.stack.id"] = def.ID
+	}
 	image.Labels["io.buildpacks.stack.description"] = imageDef.Description
 	image.Labels["io.buildpacks.stack.distro.name"] = sbom.Distro.Name
 	image.Labels["io.buildpacks.stack.distro.version"] = sbom.Distro.Version

--- a/internal/ihop/creator_test.go
+++ b/internal/ihop/creator_test.go
@@ -262,7 +262,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				UID: 3456,
 				GID: 4567,
 			},
-		})
+		}, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stack).To(Equal(ihop.Stack{
 			Build: []ihop.Image{
@@ -434,7 +434,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 					UID:        3456,
 					GID:        4567,
 				},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stack).To(Equal(ihop.Stack{
 				Build: []ihop.Image{
@@ -587,7 +587,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 						"packages": "test-run-packages",
 					},
 				},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(imageClient.UpdateCall.CallCount).To(Equal(2))
@@ -666,7 +666,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 						"packages": "test-run-packages",
 					},
 				},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(imageClient.UpdateCall.CallCount).To(Equal(2))
@@ -711,7 +711,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 					UID: 3456,
 					GID: 4567,
 				},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(imageBuilder.ExecuteCall.CallCount).To(Equal(2))
@@ -781,7 +781,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 					GID: 4567,
 				},
 				Labels: []string{"additional.label=label-value"},
-			})
+			}, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(imageClient.UpdateCall.CallCount).To(Equal(2))
@@ -805,7 +805,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}})
+				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}}, false)
 				Expect(err).To(MatchError("failed to build image: build"))
 			})
 		})
@@ -822,7 +822,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}})
+				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}}, false)
 				Expect(err).To(MatchError("failed to build image: run"))
 			})
 		})
@@ -834,7 +834,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}})
+				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}}, false)
 				Expect(err).To(MatchError("failed to create build user layer"))
 			})
 		})
@@ -850,7 +850,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}})
+				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}}, false)
 				Expect(err).To(MatchError("failed to create run user layer"))
 			})
 		})
@@ -862,7 +862,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}})
+				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}}, false)
 				Expect(err).To(MatchError("failed to update build image"))
 			})
 		})
@@ -878,7 +878,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}})
+				_, err := creator.Execute(ihop.Definition{Platforms: []string{"some-platform"}}, false)
 				Expect(err).To(MatchError("failed to update run image"))
 			})
 		})
@@ -893,7 +893,7 @@ func testCreator(t *testing.T, context spec.G, it spec.S) {
 				_, err := creator.Execute(ihop.Definition{
 					Platforms:               []string{"some-platform"},
 					IncludeExperimentalSBOM: true,
-				})
+				}, false)
 				Expect(err).To(MatchError("failed to create sbom layer"))
 			})
 		})

--- a/internal/ihop/definition.go
+++ b/internal/ihop/definition.go
@@ -154,7 +154,7 @@ func (d DefinitionImage) mergeArgs(platform string) map[string]any {
 }
 
 // NewDefinitionFromFile parses the stack descriptor from a file location.
-func NewDefinitionFromFile(path string, secrets ...string) (Definition, error) {
+func NewDefinitionFromFile(path string, noStackId bool, secrets ...string) (Definition, error) {
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return Definition{}, err
@@ -176,16 +176,23 @@ func NewDefinitionFromFile(path string, secrets ...string) (Definition, error) {
 		return Definition{}, err
 	}
 
+	if noStackId && definition.ID != "" {
+		return Definition{}, fmt.Errorf("failed to parse stack descriptor: %w", NewDefinitionConflictingStackIdError())
+	}
+
 	// check that all required fields are set
-	for field, v := range map[string]any{
-		"id":               definition.ID,
+	requiredFields := map[string]any{
 		"build.dockerfile": definition.Build.Dockerfile,
 		"build.uid":        definition.Build.UID,
 		"build.gid":        definition.Build.GID,
 		"run.dockerfile":   definition.Run.Dockerfile,
 		"run.uid":          definition.Run.UID,
 		"run.gid":          definition.Run.GID,
-	} {
+	}
+	if !noStackId {
+		requiredFields["id"] = definition.ID
+	}
+	for field, v := range requiredFields {
 		var err error
 		switch value := v.(type) {
 		case string:
@@ -271,4 +278,19 @@ func NewDefinitionRequiredFieldError(field string) DefinitionRequiredFieldError 
 // from the stack descriptor.
 func (e DefinitionRequiredFieldError) Error() string {
 	return fmt.Sprintf("'%s' is a required field", string(e))
+}
+
+// DefinitionConflictingStackIdError defines the error message when a stack id is
+// set in the descriptor while omitting stack id metadata.
+type DefinitionConflictingStackIdError struct{}
+
+// NewDefinitionConflictingStackIdError returns a DefinitionConflictingStackIdError.
+func NewDefinitionConflictingStackIdError() DefinitionConflictingStackIdError {
+	return DefinitionConflictingStackIdError{}
+}
+
+// Error returns an error message indicating that id must not be set when using
+// --no-stack-id.
+func (e DefinitionConflictingStackIdError) Error() string {
+	return "'id' must not be set when using --no-stack-id"
 }

--- a/internal/ihop/definition_test.go
+++ b/internal/ihop/definition_test.go
@@ -73,7 +73,7 @@ platforms = ["some-stack-platform"]
 		})
 
 		it("creates a definition from a config file", func() {
-			definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+			definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(definition).To(Equal(ihop.Definition{
 				ID:           "some-stack-id",
@@ -146,7 +146,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("sets the defaults", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(definition).To(Equal(ihop.Definition{
 						ID:           "some-stack-id",
@@ -193,8 +193,68 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'id' is a required field"))
+				})
+
+				it("succeeds when no stack id is allowed", func() {
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), true)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(definition.ID).To(BeEmpty())
+				})
+			})
+
+			context("when no stack id is requested", func() {
+				context("when id is missing", func() {
+					it.Before(func() {
+						err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
+name = "some-stack-name"
+homepage = "some-stack-homepage"
+
+[build]
+	dockerfile = "some-build-dockerfile"
+	uid = 1234
+	gid = 2345
+
+[run]
+	dockerfile = "some-run-dockerfile"
+	uid = 1234
+	gid = 2345
+`), 0600)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					it("succeeds", func() {
+						definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), true)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(definition.ID).To(BeEmpty())
+					})
+				})
+
+				context("when id is set", func() {
+					it.Before(func() {
+						err := os.WriteFile(filepath.Join(dir, "stack.toml"), []byte(`
+id = "some-stack-id"
+name = "some-stack-name"
+homepage = "some-stack-homepage"
+
+[build]
+	dockerfile = "some-build-dockerfile"
+	uid = 1234
+	gid = 2345
+
+[run]
+	dockerfile = "some-run-dockerfile"
+	uid = 1234
+	gid = 2345
+`), 0600)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					it("returns an error", func() {
+						_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), true)
+						Expect(err).To(MatchError("failed to parse stack descriptor: 'id' must not be set when using --no-stack-id"))
+					})
 				})
 			})
 
@@ -218,7 +278,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.dockerfile' is a required field"))
 				})
 			})
@@ -243,7 +303,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.uid' is a required field"))
 				})
 			})
@@ -269,7 +329,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'build.gid' is a required field"))
 				})
 			})
@@ -294,7 +354,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.dockerfile' is a required field"))
 				})
 			})
@@ -319,7 +379,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.uid' is a required field"))
 				})
 			})
@@ -344,7 +404,7 @@ homepage = "some-stack-homepage"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError("failed to parse stack descriptor: 'run.gid' is a required field"))
 				})
 			})
@@ -352,7 +412,7 @@ homepage = "some-stack-homepage"
 
 		context("when secrets are given", func() {
 			it("includes them in the build/run image definitions", func() {
-				definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), "first-secret=first-value", "second-secret=second-value")
+				definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false, "first-secret=first-value", "second-secret=second-value")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(definition.Build.Secrets).To(Equal(map[string]string{
 					"first-secret":  "first-value",
@@ -395,7 +455,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("transforms args to string", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).NotTo(HaveOccurred())
 					buildArgs, err := definition.Build.Arguments("linux/amd64")
 					Expect(err).NotTo(HaveOccurred())
@@ -448,7 +508,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("returns platform-specific variant", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).NotTo(HaveOccurred())
 
 					buildArgs, err := definition.Build.Arguments("linux/amd64")
@@ -489,7 +549,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("returns an error", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).ToNot(HaveOccurred())
 
 					_, err = definition.Build.Arguments("linux/amd64")
@@ -526,7 +586,7 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("returns an error", func() {
-					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					definition, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).ToNot(HaveOccurred())
 
 					buildArgs, err := definition.Build.Arguments("linux/amd64")
@@ -542,7 +602,7 @@ homepage = "https://github.com/some-stack"
 		context("failure cases", func() {
 			context("when the file cannot be opened", func() {
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile("this file does not exist")
+					_, err := ihop.NewDefinitionFromFile("this file does not exist", false)
 					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 				})
 			})
@@ -554,14 +614,14 @@ homepage = "https://github.com/some-stack"
 				})
 
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"))
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false)
 					Expect(err).To(MatchError(ContainSubstring("but got '%' instead")))
 				})
 			})
 
 			context("when a secret is malformed", func() {
 				it("returns an error", func() {
-					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), "this secret is malformed")
+					_, err := ihop.NewDefinitionFromFile(filepath.Join(dir, "stack.toml"), false, "this secret is malformed")
 					Expect(err).To(MatchError("malformed secret: \"this secret is malformed\" must be in the form \"key=value\""))
 				})
 			})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds a new flag on the create-stack command called `--no-stack-id` which removes the stack id from the base images if this flag has been set.

## Use Cases
<!-- An explanation of the use cases your change enables -->
While we move away from the stacks, we want to do that slowly keeping any backward compatibility with the current implementation of the stacks/ base images. Therefore, we introduce the aforementioned flag which allows to deprecated the main differentiation which distinguishes the stacks with the no-stacks base images while we keep on producing the base images as we used to with the stacks by keeping the same infrastructure implementation.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
